### PR TITLE
Choropleth Update: Use Static Data and Tippy Tooltips

### DIFF
--- a/civicwatch_backend/static/data/defaultChoroplethEngagement.json
+++ b/civicwatch_backend/static/data/defaultChoroplethEngagement.json
@@ -1,302 +1,4002 @@
 [
     {
-        "state": "AK",
-        "Democratic": 932627,
-        "Republican": 8986,
-        "total": 941613
+      "state": "AK",
+      "Democratic": 932660,
+      "Republican": 8984,
+      "total": 941644,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 1,
+          "Republican": 0,
+          "total": 1
+        },
+        "capitol": {
+          "Democratic": 343758,
+          "Republican": 5,
+          "total": 343763
+        },
+        "climate": {
+          "Democratic": 124,
+          "Republican": 0,
+          "total": 124
+        },
+        "covid": {
+          "Democratic": 513935,
+          "Republican": 8979,
+          "total": 522914
+        },
+        "gun": {
+          "Democratic": 91,
+          "Republican": 0,
+          "total": 91
+        },
+        "immigra": {
+          "Democratic": 2,
+          "Republican": 0,
+          "total": 2
+        },
+        "rights": {
+          "Democratic": 74749,
+          "Republican": 0,
+          "total": 74749
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 1,
+          "Republican": 0,
+          "total": 1
+        },
+        "capitol": {
+          "Democratic": 343758,
+          "Republican": 5,
+          "total": 343763
+        },
+        "climate": {
+          "Democratic": 124,
+          "Republican": 0,
+          "total": 124
+        },
+        "covid": {
+          "Democratic": 513935,
+          "Republican": 8979,
+          "total": 522914
+        },
+        "gun": {
+          "Democratic": 91,
+          "Republican": 0,
+          "total": 91
+        },
+        "immigra": {
+          "Democratic": 2,
+          "Republican": 0,
+          "total": 2
+        },
+        "rights": {
+          "Democratic": 74749,
+          "Republican": 0,
+          "total": 74749
+        }
+      }
     },
     {
-        "state": "AL",
-        "Democratic": 852094,
-        "Republican": 4905775,
-        "total": 5757869
+      "state": "AL",
+      "Democratic": 804589,
+      "Republican": 3639191,
+      "total": 4443780,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 382,
+          "Republican": 69391,
+          "total": 69773
+        },
+        "capitol": {
+          "Democratic": 1931,
+          "Republican": 81654,
+          "total": 83585
+        },
+        "climate": {
+          "Democratic": 1,
+          "Republican": 70635,
+          "total": 70636
+        },
+        "covid": {
+          "Democratic": 552993,
+          "Republican": 2843942,
+          "total": 3396935
+        },
+        "gun": {
+          "Democratic": 131306,
+          "Republican": 288030,
+          "total": 419336
+        },
+        "immigra": {
+          "Democratic": 54151,
+          "Republican": 64376,
+          "total": 118527
+        },
+        "rights": {
+          "Democratic": 63825,
+          "Republican": 221163,
+          "total": 284988
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 382,
+          "Republican": 69391,
+          "total": 69773
+        },
+        "capitol": {
+          "Democratic": 1931,
+          "Republican": 81654,
+          "total": 83585
+        },
+        "climate": {
+          "Democratic": 1,
+          "Republican": 70635,
+          "total": 70636
+        },
+        "covid": {
+          "Democratic": 552993,
+          "Republican": 2843942,
+          "total": 3396935
+        },
+        "gun": {
+          "Democratic": 131306,
+          "Republican": 288030,
+          "total": 419336
+        },
+        "immigra": {
+          "Democratic": 54151,
+          "Republican": 64376,
+          "total": 118527
+        },
+        "rights": {
+          "Democratic": 63825,
+          "Republican": 221163,
+          "total": 284988
+        }
+      }
     },
     {
-        "state": "AR",
-        "Democratic": 1537046,
-        "Republican": 2778859,
-        "total": 4315905
+      "state": "AR",
+      "Democratic": 1455890,
+      "Republican": 2345717,
+      "total": 3801607,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 1549,
+          "Republican": 258823,
+          "total": 260372
+        },
+        "capitol": {
+          "Democratic": 369726,
+          "Republican": 36082,
+          "total": 405808
+        },
+        "climate": {
+          "Democratic": 37276,
+          "Republican": 13344,
+          "total": 50620
+        },
+        "covid": {
+          "Democratic": 803302,
+          "Republican": 1265859,
+          "total": 2069161
+        },
+        "gun": {
+          "Democratic": 66475,
+          "Republican": 602476,
+          "total": 668951
+        },
+        "immigra": {
+          "Democratic": 42175,
+          "Republican": 25905,
+          "total": 68080
+        },
+        "rights": {
+          "Democratic": 135387,
+          "Republican": 143228,
+          "total": 278615
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 1549,
+          "Republican": 258823,
+          "total": 260372
+        },
+        "capitol": {
+          "Democratic": 369726,
+          "Republican": 36082,
+          "total": 405808
+        },
+        "climate": {
+          "Democratic": 37276,
+          "Republican": 13344,
+          "total": 50620
+        },
+        "covid": {
+          "Democratic": 803302,
+          "Republican": 1265859,
+          "total": 2069161
+        },
+        "gun": {
+          "Democratic": 66475,
+          "Republican": 602476,
+          "total": 668951
+        },
+        "immigra": {
+          "Democratic": 42175,
+          "Republican": 25905,
+          "total": 68080
+        },
+        "rights": {
+          "Democratic": 135387,
+          "Republican": 143228,
+          "total": 278615
+        }
+      }
     },
     {
-        "state": "AZ",
-        "Democratic": 16521994,
-        "Republican": 8536567,
-        "total": 25058561
+      "state": "AZ",
+      "Democratic": 14466685,
+      "Republican": 7952641,
+      "total": 22419326,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 300064,
+          "Republican": 495222,
+          "total": 795286
+        },
+        "capitol": {
+          "Democratic": 3320379,
+          "Republican": 682907,
+          "total": 4003286
+        },
+        "climate": {
+          "Democratic": 572936,
+          "Republican": 238248,
+          "total": 811184
+        },
+        "covid": {
+          "Democratic": 7959154,
+          "Republican": 4291442,
+          "total": 12250596
+        },
+        "gun": {
+          "Democratic": 667026,
+          "Republican": 1073917,
+          "total": 1740943
+        },
+        "immigra": {
+          "Democratic": 537766,
+          "Republican": 676137,
+          "total": 1213903
+        },
+        "rights": {
+          "Democratic": 1109360,
+          "Republican": 494768,
+          "total": 1604128
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 300064,
+          "Republican": 495222,
+          "total": 795286
+        },
+        "capitol": {
+          "Democratic": 3320379,
+          "Republican": 682907,
+          "total": 4003286
+        },
+        "climate": {
+          "Democratic": 572936,
+          "Republican": 238248,
+          "total": 811184
+        },
+        "covid": {
+          "Democratic": 7959154,
+          "Republican": 4291442,
+          "total": 12250596
+        },
+        "gun": {
+          "Democratic": 667026,
+          "Republican": 1073917,
+          "total": 1740943
+        },
+        "immigra": {
+          "Democratic": 537766,
+          "Republican": 676137,
+          "total": 1213903
+        },
+        "rights": {
+          "Democratic": 1109360,
+          "Republican": 494768,
+          "total": 1604128
+        }
+      }
     },
     {
-        "state": "CA",
-        "Democratic": 13199179,
-        "Republican": 1055083,
-        "total": 14254262
+      "state": "CA",
+      "Democratic": 10175223,
+      "Republican": 1045126,
+      "total": 11220349,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 232663,
+          "Republican": 0,
+          "total": 232663
+        },
+        "capitol": {
+          "Democratic": 753075,
+          "Republican": 352860,
+          "total": 1105935
+        },
+        "climate": {
+          "Democratic": 868236,
+          "Republican": 15872,
+          "total": 884108
+        },
+        "covid": {
+          "Democratic": 6263091,
+          "Republican": 592849,
+          "total": 6855940
+        },
+        "gun": {
+          "Democratic": 951401,
+          "Republican": 12768,
+          "total": 964169
+        },
+        "immigra": {
+          "Democratic": 294487,
+          "Republican": 1008,
+          "total": 295495
+        },
+        "rights": {
+          "Democratic": 812270,
+          "Republican": 69769,
+          "total": 882039
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 232663,
+          "Republican": 0,
+          "total": 232663
+        },
+        "capitol": {
+          "Democratic": 753075,
+          "Republican": 352860,
+          "total": 1105935
+        },
+        "climate": {
+          "Democratic": 868236,
+          "Republican": 15872,
+          "total": 884108
+        },
+        "covid": {
+          "Democratic": 6263091,
+          "Republican": 592849,
+          "total": 6855940
+        },
+        "gun": {
+          "Democratic": 951401,
+          "Republican": 12768,
+          "total": 964169
+        },
+        "immigra": {
+          "Democratic": 294487,
+          "Republican": 1008,
+          "total": 295495
+        },
+        "rights": {
+          "Democratic": 812270,
+          "Republican": 69769,
+          "total": 882039
+        }
+      }
     },
     {
-        "state": "CO",
-        "Democratic": 6922931,
-        "Republican": 396076,
-        "total": 7319007
+      "state": "CO",
+      "Democratic": 4559274,
+      "Republican": 857596,
+      "total": 5416870,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 76734,
+          "Republican": 97,
+          "total": 76831
+        },
+        "capitol": {
+          "Democratic": 1233592,
+          "Republican": 363846,
+          "total": 1597438
+        },
+        "climate": {
+          "Democratic": 290911,
+          "Republican": 70,
+          "total": 290981
+        },
+        "covid": {
+          "Democratic": 2360619,
+          "Republican": 203431,
+          "total": 2564050
+        },
+        "gun": {
+          "Democratic": 250700,
+          "Republican": 72287,
+          "total": 322987
+        },
+        "immigra": {
+          "Democratic": 151290,
+          "Republican": 150154,
+          "total": 301444
+        },
+        "rights": {
+          "Democratic": 195428,
+          "Republican": 67711,
+          "total": 263139
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 76734,
+          "Republican": 97,
+          "total": 76831
+        },
+        "capitol": {
+          "Democratic": 1233592,
+          "Republican": 363846,
+          "total": 1597438
+        },
+        "climate": {
+          "Democratic": 290911,
+          "Republican": 70,
+          "total": 290981
+        },
+        "covid": {
+          "Democratic": 2360619,
+          "Republican": 203431,
+          "total": 2564050
+        },
+        "gun": {
+          "Democratic": 250700,
+          "Republican": 72287,
+          "total": 322987
+        },
+        "immigra": {
+          "Democratic": 151290,
+          "Republican": 150154,
+          "total": 301444
+        },
+        "rights": {
+          "Democratic": 195428,
+          "Republican": 67711,
+          "total": 263139
+        }
+      }
     },
     {
-        "state": "CT",
-        "Democratic": 3184399,
-        "Republican": 174032,
-        "total": 3358431
+      "state": "CT",
+      "Democratic": 2636162,
+      "Republican": 170492,
+      "total": 2806654,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 16755,
+          "Republican": 0,
+          "total": 16755
+        },
+        "capitol": {
+          "Democratic": 151860,
+          "Republican": 5016,
+          "total": 156876
+        },
+        "climate": {
+          "Democratic": 211125,
+          "Republican": 42,
+          "total": 211167
+        },
+        "covid": {
+          "Democratic": 2022634,
+          "Republican": 165287,
+          "total": 2187921
+        },
+        "gun": {
+          "Democratic": 44287,
+          "Republican": 26,
+          "total": 44313
+        },
+        "immigra": {
+          "Democratic": 7186,
+          "Republican": 3,
+          "total": 7189
+        },
+        "rights": {
+          "Democratic": 182315,
+          "Republican": 118,
+          "total": 182433
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 16755,
+          "Republican": 0,
+          "total": 16755
+        },
+        "capitol": {
+          "Democratic": 151860,
+          "Republican": 5016,
+          "total": 156876
+        },
+        "climate": {
+          "Democratic": 211125,
+          "Republican": 42,
+          "total": 211167
+        },
+        "covid": {
+          "Democratic": 2022634,
+          "Republican": 165287,
+          "total": 2187921
+        },
+        "gun": {
+          "Democratic": 44287,
+          "Republican": 26,
+          "total": 44313
+        },
+        "immigra": {
+          "Democratic": 7186,
+          "Republican": 3,
+          "total": 7189
+        },
+        "rights": {
+          "Democratic": 182315,
+          "Republican": 118,
+          "total": 182433
+        }
+      }
     },
     {
-        "state": "DE",
-        "Democratic": 6946458,
-        "Republican": 27,
-        "total": 6946485
+      "state": "DE",
+      "Democratic": 6240159,
+      "Republican": 27,
+      "total": 6240186,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 98152,
+          "Republican": 0,
+          "total": 98152
+        },
+        "capitol": {
+          "Democratic": 1205569,
+          "Republican": 0,
+          "total": 1205569
+        },
+        "climate": {
+          "Democratic": 195580,
+          "Republican": 0,
+          "total": 195580
+        },
+        "covid": {
+          "Democratic": 3384514,
+          "Republican": 27,
+          "total": 3384541
+        },
+        "gun": {
+          "Democratic": 612297,
+          "Republican": 0,
+          "total": 612297
+        },
+        "immigra": {
+          "Democratic": 170851,
+          "Republican": 0,
+          "total": 170851
+        },
+        "rights": {
+          "Democratic": 573196,
+          "Republican": 0,
+          "total": 573196
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 98152,
+          "Republican": 0,
+          "total": 98152
+        },
+        "capitol": {
+          "Democratic": 1205569,
+          "Republican": 0,
+          "total": 1205569
+        },
+        "climate": {
+          "Democratic": 195580,
+          "Republican": 0,
+          "total": 195580
+        },
+        "covid": {
+          "Democratic": 3384514,
+          "Republican": 27,
+          "total": 3384541
+        },
+        "gun": {
+          "Democratic": 612297,
+          "Republican": 0,
+          "total": 612297
+        },
+        "immigra": {
+          "Democratic": 170851,
+          "Republican": 0,
+          "total": 170851
+        },
+        "rights": {
+          "Democratic": 573196,
+          "Republican": 0,
+          "total": 573196
+        }
+      }
     },
     {
-        "state": "FL",
-        "Democratic": 4907957,
-        "Republican": 2419056,
-        "total": 7327013
+      "state": "FL",
+      "Democratic": 4285982,
+      "Republican": 2336411,
+      "total": 6622393,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 78941,
+          "Republican": 53439,
+          "total": 132380
+        },
+        "capitol": {
+          "Democratic": 242367,
+          "Republican": 115233,
+          "total": 357600
+        },
+        "climate": {
+          "Democratic": 202790,
+          "Republican": 55465,
+          "total": 258255
+        },
+        "covid": {
+          "Democratic": 2871859,
+          "Republican": 1839089,
+          "total": 4710948
+        },
+        "gun": {
+          "Democratic": 293164,
+          "Republican": 74673,
+          "total": 367837
+        },
+        "immigra": {
+          "Democratic": 22782,
+          "Republican": 126448,
+          "total": 149230
+        },
+        "rights": {
+          "Democratic": 574079,
+          "Republican": 72064,
+          "total": 646143
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 78941,
+          "Republican": 53439,
+          "total": 132380
+        },
+        "capitol": {
+          "Democratic": 242367,
+          "Republican": 115233,
+          "total": 357600
+        },
+        "climate": {
+          "Democratic": 202790,
+          "Republican": 55465,
+          "total": 258255
+        },
+        "covid": {
+          "Democratic": 2871859,
+          "Republican": 1839089,
+          "total": 4710948
+        },
+        "gun": {
+          "Democratic": 293164,
+          "Republican": 74673,
+          "total": 367837
+        },
+        "immigra": {
+          "Democratic": 22782,
+          "Republican": 126448,
+          "total": 149230
+        },
+        "rights": {
+          "Democratic": 574079,
+          "Republican": 72064,
+          "total": 646143
+        }
+      }
     },
     {
-        "state": "GA",
-        "Democratic": 5873572,
-        "Republican": 892333,
-        "total": 6765905
+      "state": "GA",
+      "Democratic": 5176048,
+      "Republican": 870054,
+      "total": 6046102,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 83279,
+          "Republican": 50074,
+          "total": 133353
+        },
+        "capitol": {
+          "Democratic": 744258,
+          "Republican": 21515,
+          "total": 765773
+        },
+        "climate": {
+          "Democratic": 235038,
+          "Republican": 40788,
+          "total": 275826
+        },
+        "covid": {
+          "Democratic": 3299993,
+          "Republican": 530840,
+          "total": 3830833
+        },
+        "gun": {
+          "Democratic": 268517,
+          "Republican": 66910,
+          "total": 335427
+        },
+        "immigra": {
+          "Democratic": 107883,
+          "Republican": 31514,
+          "total": 139397
+        },
+        "rights": {
+          "Democratic": 437080,
+          "Republican": 128413,
+          "total": 565493
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 83279,
+          "Republican": 50074,
+          "total": 133353
+        },
+        "capitol": {
+          "Democratic": 744258,
+          "Republican": 21515,
+          "total": 765773
+        },
+        "climate": {
+          "Democratic": 235038,
+          "Republican": 40788,
+          "total": 275826
+        },
+        "covid": {
+          "Democratic": 3299993,
+          "Republican": 530840,
+          "total": 3830833
+        },
+        "gun": {
+          "Democratic": 268517,
+          "Republican": 66910,
+          "total": 335427
+        },
+        "immigra": {
+          "Democratic": 107883,
+          "Republican": 31514,
+          "total": 139397
+        },
+        "rights": {
+          "Democratic": 437080,
+          "Republican": 128413,
+          "total": 565493
+        }
+      }
     },
     {
-        "state": "HI",
-        "Democratic": 411236,
-        "Republican": 649,
-        "total": 411885
+      "state": "HI",
+      "Democratic": 362361,
+      "Republican": 632,
+      "total": 362993,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 19,
+          "Republican": 2,
+          "total": 21
+        },
+        "capitol": {
+          "Democratic": 151797,
+          "Republican": 0,
+          "total": 151797
+        },
+        "climate": {
+          "Democratic": 22461,
+          "Republican": 0,
+          "total": 22461
+        },
+        "covid": {
+          "Democratic": 141137,
+          "Republican": 602,
+          "total": 141739
+        },
+        "gun": {
+          "Democratic": 12527,
+          "Republican": 1,
+          "total": 12528
+        },
+        "immigra": {
+          "Democratic": 960,
+          "Republican": 0,
+          "total": 960
+        },
+        "rights": {
+          "Democratic": 33460,
+          "Republican": 27,
+          "total": 33487
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 19,
+          "Republican": 2,
+          "total": 21
+        },
+        "capitol": {
+          "Democratic": 151797,
+          "Republican": 0,
+          "total": 151797
+        },
+        "climate": {
+          "Democratic": 22461,
+          "Republican": 0,
+          "total": 22461
+        },
+        "covid": {
+          "Democratic": 141137,
+          "Republican": 602,
+          "total": 141739
+        },
+        "gun": {
+          "Democratic": 12527,
+          "Republican": 1,
+          "total": 12528
+        },
+        "immigra": {
+          "Democratic": 960,
+          "Republican": 0,
+          "total": 960
+        },
+        "rights": {
+          "Democratic": 33460,
+          "Republican": 27,
+          "total": 33487
+        }
+      }
     },
     {
-        "state": "IA",
-        "Democratic": 1676262,
-        "Republican": 110162,
-        "total": 1786424
+      "state": "IA",
+      "Democratic": 1137355,
+      "Republican": 109309,
+      "total": 1246664,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 11098,
+          "Republican": 1392,
+          "total": 12490
+        },
+        "capitol": {
+          "Democratic": 213303,
+          "Republican": 88,
+          "total": 213391
+        },
+        "climate": {
+          "Democratic": 134893,
+          "Republican": 698,
+          "total": 135591
+        },
+        "covid": {
+          "Democratic": 600624,
+          "Republican": 103836,
+          "total": 704460
+        },
+        "gun": {
+          "Democratic": 55423,
+          "Republican": 1646,
+          "total": 57069
+        },
+        "immigra": {
+          "Democratic": 26607,
+          "Republican": 945,
+          "total": 27552
+        },
+        "rights": {
+          "Democratic": 95407,
+          "Republican": 704,
+          "total": 96111
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 11098,
+          "Republican": 1392,
+          "total": 12490
+        },
+        "capitol": {
+          "Democratic": 213303,
+          "Republican": 88,
+          "total": 213391
+        },
+        "climate": {
+          "Democratic": 134893,
+          "Republican": 698,
+          "total": 135591
+        },
+        "covid": {
+          "Democratic": 600624,
+          "Republican": 103836,
+          "total": 704460
+        },
+        "gun": {
+          "Democratic": 55423,
+          "Republican": 1646,
+          "total": 57069
+        },
+        "immigra": {
+          "Democratic": 26607,
+          "Republican": 945,
+          "total": 27552
+        },
+        "rights": {
+          "Democratic": 95407,
+          "Republican": 704,
+          "total": 96111
+        }
+      }
     },
     {
-        "state": "ID",
-        "Democratic": 430739,
-        "Republican": 146306,
-        "total": 577045
+      "state": "ID",
+      "Democratic": 793336,
+      "Republican": 146145,
+      "total": 939481,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 625,
+          "Republican": 3,
+          "total": 628
+        },
+        "capitol": {
+          "Democratic": 44738,
+          "Republican": 10138,
+          "total": 54876
+        },
+        "climate": {
+          "Democratic": 512967,
+          "Republican": 61,
+          "total": 513028
+        },
+        "covid": {
+          "Democratic": 206913,
+          "Republican": 120799,
+          "total": 327712
+        },
+        "gun": {
+          "Democratic": 15196,
+          "Republican": 697,
+          "total": 15893
+        },
+        "immigra": {
+          "Democratic": 723,
+          "Republican": 11706,
+          "total": 12429
+        },
+        "rights": {
+          "Democratic": 12174,
+          "Republican": 2741,
+          "total": 14915
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 625,
+          "Republican": 3,
+          "total": 628
+        },
+        "capitol": {
+          "Democratic": 44738,
+          "Republican": 10138,
+          "total": 54876
+        },
+        "climate": {
+          "Democratic": 512967,
+          "Republican": 61,
+          "total": 513028
+        },
+        "covid": {
+          "Democratic": 206913,
+          "Republican": 120799,
+          "total": 327712
+        },
+        "gun": {
+          "Democratic": 15196,
+          "Republican": 697,
+          "total": 15893
+        },
+        "immigra": {
+          "Democratic": 723,
+          "Republican": 11706,
+          "total": 12429
+        },
+        "rights": {
+          "Democratic": 12174,
+          "Republican": 2741,
+          "total": 14915
+        }
+      }
     },
     {
-        "state": "IL",
-        "Democratic": 1651306,
-        "Republican": 490092,
-        "total": 2141398
+      "state": "IL",
+      "Democratic": 1409670,
+      "Republican": 467842,
+      "total": 1877512,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 16991,
+          "Republican": 34202,
+          "total": 51193
+        },
+        "capitol": {
+          "Democratic": 26635,
+          "Republican": 84956,
+          "total": 111591
+        },
+        "climate": {
+          "Democratic": 62157,
+          "Republican": 2121,
+          "total": 64278
+        },
+        "covid": {
+          "Democratic": 1171164,
+          "Republican": 309136,
+          "total": 1480300
+        },
+        "gun": {
+          "Democratic": 94533,
+          "Republican": 22329,
+          "total": 116862
+        },
+        "immigra": {
+          "Democratic": 1150,
+          "Republican": 5209,
+          "total": 6359
+        },
+        "rights": {
+          "Democratic": 37040,
+          "Republican": 9889,
+          "total": 46929
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 16991,
+          "Republican": 34202,
+          "total": 51193
+        },
+        "capitol": {
+          "Democratic": 26635,
+          "Republican": 84956,
+          "total": 111591
+        },
+        "climate": {
+          "Democratic": 62157,
+          "Republican": 2121,
+          "total": 64278
+        },
+        "covid": {
+          "Democratic": 1171164,
+          "Republican": 309136,
+          "total": 1480300
+        },
+        "gun": {
+          "Democratic": 94533,
+          "Republican": 22329,
+          "total": 116862
+        },
+        "immigra": {
+          "Democratic": 1150,
+          "Republican": 5209,
+          "total": 6359
+        },
+        "rights": {
+          "Democratic": 37040,
+          "Republican": 9889,
+          "total": 46929
+        }
+      }
     },
     {
-        "state": "IN",
-        "Democratic": 388342,
-        "Republican": 1045284,
-        "total": 1433626
+      "state": "IN",
+      "Democratic": 323224,
+      "Republican": 967052,
+      "total": 1290276,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 34,
+          "Republican": 57053,
+          "total": 57087
+        },
+        "capitol": {
+          "Democratic": 1,
+          "Republican": 10304,
+          "total": 10305
+        },
+        "climate": {
+          "Democratic": 419,
+          "Republican": 11021,
+          "total": 11440
+        },
+        "covid": {
+          "Democratic": 302337,
+          "Republican": 813457,
+          "total": 1115794
+        },
+        "gun": {
+          "Democratic": 622,
+          "Republican": 35315,
+          "total": 35937
+        },
+        "immigra": {
+          "Democratic": 175,
+          "Republican": 7838,
+          "total": 8013
+        },
+        "rights": {
+          "Democratic": 19636,
+          "Republican": 32064,
+          "total": 51700
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 34,
+          "Republican": 57053,
+          "total": 57087
+        },
+        "capitol": {
+          "Democratic": 1,
+          "Republican": 10304,
+          "total": 10305
+        },
+        "climate": {
+          "Democratic": 419,
+          "Republican": 11021,
+          "total": 11440
+        },
+        "covid": {
+          "Democratic": 302337,
+          "Republican": 813457,
+          "total": 1115794
+        },
+        "gun": {
+          "Democratic": 622,
+          "Republican": 35315,
+          "total": 35937
+        },
+        "immigra": {
+          "Democratic": 175,
+          "Republican": 7838,
+          "total": 8013
+        },
+        "rights": {
+          "Democratic": 19636,
+          "Republican": 32064,
+          "total": 51700
+        }
+      }
     },
     {
-        "state": "KS",
-        "Democratic": 1384442,
-        "Republican": 472885,
-        "total": 1857327
+      "state": "KS",
+      "Democratic": 1098712,
+      "Republican": 470240,
+      "total": 1568952,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 24375,
+          "Republican": 3520,
+          "total": 27895
+        },
+        "capitol": {
+          "Democratic": 306516,
+          "Republican": 6,
+          "total": 306522
+        },
+        "climate": {
+          "Democratic": 85664,
+          "Republican": 11461,
+          "total": 97125
+        },
+        "covid": {
+          "Democratic": 450236,
+          "Republican": 449388,
+          "total": 899624
+        },
+        "gun": {
+          "Democratic": 131213,
+          "Republican": 3950,
+          "total": 135163
+        },
+        "immigra": {
+          "Democratic": 14014,
+          "Republican": 1551,
+          "total": 15565
+        },
+        "rights": {
+          "Democratic": 86694,
+          "Republican": 364,
+          "total": 87058
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 24375,
+          "Republican": 3520,
+          "total": 27895
+        },
+        "capitol": {
+          "Democratic": 306516,
+          "Republican": 6,
+          "total": 306522
+        },
+        "climate": {
+          "Democratic": 85664,
+          "Republican": 11461,
+          "total": 97125
+        },
+        "covid": {
+          "Democratic": 450236,
+          "Republican": 449388,
+          "total": 899624
+        },
+        "gun": {
+          "Democratic": 131213,
+          "Republican": 3950,
+          "total": 135163
+        },
+        "immigra": {
+          "Democratic": 14014,
+          "Republican": 1551,
+          "total": 15565
+        },
+        "rights": {
+          "Democratic": 86694,
+          "Republican": 364,
+          "total": 87058
+        }
+      }
     },
     {
-        "state": "KY",
-        "Democratic": 4329135,
-        "Republican": 682223,
-        "total": 5011358
+      "state": "KY",
+      "Democratic": 3568253,
+      "Republican": 679212,
+      "total": 4247465,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 46396,
+          "Republican": 39606,
+          "total": 86002
+        },
+        "capitol": {
+          "Democratic": 523253,
+          "Republican": 28407,
+          "total": 551660
+        },
+        "climate": {
+          "Democratic": 140784,
+          "Republican": 1178,
+          "total": 141962
+        },
+        "covid": {
+          "Democratic": 1616773,
+          "Republican": 550020,
+          "total": 2166793
+        },
+        "gun": {
+          "Democratic": 312940,
+          "Republican": 37514,
+          "total": 350454
+        },
+        "immigra": {
+          "Democratic": 329206,
+          "Republican": 16329,
+          "total": 345535
+        },
+        "rights": {
+          "Democratic": 598901,
+          "Republican": 6158,
+          "total": 605059
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 46396,
+          "Republican": 39606,
+          "total": 86002
+        },
+        "capitol": {
+          "Democratic": 523253,
+          "Republican": 28407,
+          "total": 551660
+        },
+        "climate": {
+          "Democratic": 140784,
+          "Republican": 1178,
+          "total": 141962
+        },
+        "covid": {
+          "Democratic": 1616773,
+          "Republican": 550020,
+          "total": 2166793
+        },
+        "gun": {
+          "Democratic": 312940,
+          "Republican": 37514,
+          "total": 350454
+        },
+        "immigra": {
+          "Democratic": 329206,
+          "Republican": 16329,
+          "total": 345535
+        },
+        "rights": {
+          "Democratic": 598901,
+          "Republican": 6158,
+          "total": 605059
+        }
+      }
     },
     {
-        "state": "LA",
-        "Democratic": 1271926,
-        "Republican": 299815,
-        "total": 1571741
+      "state": "LA",
+      "Democratic": 970142,
+      "Republican": 302092,
+      "total": 1272234,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 8400,
+          "Republican": 4231,
+          "total": 12631
+        },
+        "capitol": {
+          "Democratic": 4177,
+          "Republican": 43997,
+          "total": 48174
+        },
+        "climate": {
+          "Democratic": 55881,
+          "Republican": 12451,
+          "total": 68332
+        },
+        "covid": {
+          "Democratic": 689483,
+          "Republican": 214632,
+          "total": 904115
+        },
+        "gun": {
+          "Democratic": 23254,
+          "Republican": 10373,
+          "total": 33627
+        },
+        "immigra": {
+          "Democratic": 25763,
+          "Republican": 695,
+          "total": 26458
+        },
+        "rights": {
+          "Democratic": 163184,
+          "Republican": 15713,
+          "total": 178897
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 8400,
+          "Republican": 4231,
+          "total": 12631
+        },
+        "capitol": {
+          "Democratic": 4177,
+          "Republican": 43997,
+          "total": 48174
+        },
+        "climate": {
+          "Democratic": 55881,
+          "Republican": 12451,
+          "total": 68332
+        },
+        "covid": {
+          "Democratic": 689483,
+          "Republican": 214632,
+          "total": 904115
+        },
+        "gun": {
+          "Democratic": 23254,
+          "Republican": 10373,
+          "total": 33627
+        },
+        "immigra": {
+          "Democratic": 25763,
+          "Republican": 695,
+          "total": 26458
+        },
+        "rights": {
+          "Democratic": 163184,
+          "Republican": 15713,
+          "total": 178897
+        }
+      }
     },
     {
-        "state": "MA",
-        "Democratic": 9966569,
-        "Republican": 150793,
-        "total": 10117362
+      "state": "MA",
+      "Democratic": 9185694,
+      "Republican": 148886,
+      "total": 9334580,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 65354,
+          "Republican": 1,
+          "total": 65355
+        },
+        "capitol": {
+          "Democratic": 134241,
+          "Republican": 2,
+          "total": 134243
+        },
+        "climate": {
+          "Democratic": 781101,
+          "Republican": 3553,
+          "total": 784654
+        },
+        "covid": {
+          "Democratic": 7180999,
+          "Republican": 144714,
+          "total": 7325713
+        },
+        "gun": {
+          "Democratic": 211367,
+          "Republican": 207,
+          "total": 211574
+        },
+        "immigra": {
+          "Democratic": 369252,
+          "Republican": 83,
+          "total": 369335
+        },
+        "rights": {
+          "Democratic": 443380,
+          "Republican": 326,
+          "total": 443706
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 65354,
+          "Republican": 1,
+          "total": 65355
+        },
+        "capitol": {
+          "Democratic": 134241,
+          "Republican": 2,
+          "total": 134243
+        },
+        "climate": {
+          "Democratic": 781101,
+          "Republican": 3553,
+          "total": 784654
+        },
+        "covid": {
+          "Democratic": 7180999,
+          "Republican": 144714,
+          "total": 7325713
+        },
+        "gun": {
+          "Democratic": 211367,
+          "Republican": 207,
+          "total": 211574
+        },
+        "immigra": {
+          "Democratic": 369252,
+          "Republican": 83,
+          "total": 369335
+        },
+        "rights": {
+          "Democratic": 443380,
+          "Republican": 326,
+          "total": 443706
+        }
+      }
     },
     {
-        "state": "MD",
-        "Democratic": 9690524,
-        "Republican": 1019461,
-        "total": 10709985
+      "state": "MD",
+      "Democratic": 7541218,
+      "Republican": 908500,
+      "total": 8449718,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 123498,
+          "Republican": 22700,
+          "total": 146198
+        },
+        "capitol": {
+          "Democratic": 1695458,
+          "Republican": 55573,
+          "total": 1751031
+        },
+        "climate": {
+          "Democratic": 431040,
+          "Republican": 4020,
+          "total": 435060
+        },
+        "covid": {
+          "Democratic": 3749202,
+          "Republican": 727643,
+          "total": 4476845
+        },
+        "gun": {
+          "Democratic": 380007,
+          "Republican": 50096,
+          "total": 430103
+        },
+        "immigra": {
+          "Democratic": 460438,
+          "Republican": 22558,
+          "total": 482996
+        },
+        "rights": {
+          "Democratic": 701575,
+          "Republican": 25910,
+          "total": 727485
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 123498,
+          "Republican": 22700,
+          "total": 146198
+        },
+        "capitol": {
+          "Democratic": 1695458,
+          "Republican": 55573,
+          "total": 1751031
+        },
+        "climate": {
+          "Democratic": 431040,
+          "Republican": 4020,
+          "total": 435060
+        },
+        "covid": {
+          "Democratic": 3749202,
+          "Republican": 727643,
+          "total": 4476845
+        },
+        "gun": {
+          "Democratic": 380007,
+          "Republican": 50096,
+          "total": 430103
+        },
+        "immigra": {
+          "Democratic": 460438,
+          "Republican": 22558,
+          "total": 482996
+        },
+        "rights": {
+          "Democratic": 701575,
+          "Republican": 25910,
+          "total": 727485
+        }
+      }
     },
     {
-        "state": "ME",
-        "Democratic": 4910581,
-        "Republican": 33190,
-        "total": 4943771
+      "state": "ME",
+      "Democratic": 3698995,
+      "Republican": 33187,
+      "total": 3732182,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 46482,
+          "Republican": 0,
+          "total": 46482
+        },
+        "capitol": {
+          "Democratic": 469213,
+          "Republican": 30106,
+          "total": 499319
+        },
+        "climate": {
+          "Democratic": 365466,
+          "Republican": 3,
+          "total": 365469
+        },
+        "covid": {
+          "Democratic": 2157919,
+          "Republican": 3067,
+          "total": 2160986
+        },
+        "gun": {
+          "Democratic": 113366,
+          "Republican": 11,
+          "total": 113377
+        },
+        "immigra": {
+          "Democratic": 61271,
+          "Republican": 0,
+          "total": 61271
+        },
+        "rights": {
+          "Democratic": 485278,
+          "Republican": 0,
+          "total": 485278
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 46482,
+          "Republican": 0,
+          "total": 46482
+        },
+        "capitol": {
+          "Democratic": 469213,
+          "Republican": 30106,
+          "total": 499319
+        },
+        "climate": {
+          "Democratic": 365466,
+          "Republican": 3,
+          "total": 365469
+        },
+        "covid": {
+          "Democratic": 2157919,
+          "Republican": 3067,
+          "total": 2160986
+        },
+        "gun": {
+          "Democratic": 113366,
+          "Republican": 11,
+          "total": 113377
+        },
+        "immigra": {
+          "Democratic": 61271,
+          "Republican": 0,
+          "total": 61271
+        },
+        "rights": {
+          "Democratic": 485278,
+          "Republican": 0,
+          "total": 485278
+        }
+      }
     },
     {
-        "state": "MI",
-        "Democratic": 7517204,
-        "Republican": 329739,
-        "total": 7846943
+      "state": "MI",
+      "Democratic": 4587825,
+      "Republican": 305690,
+      "total": 4893515,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 58675,
+          "Republican": 3636,
+          "total": 62311
+        },
+        "capitol": {
+          "Democratic": 364075,
+          "Republican": 3295,
+          "total": 367370
+        },
+        "climate": {
+          "Democratic": 231253,
+          "Republican": 5091,
+          "total": 236344
+        },
+        "covid": {
+          "Democratic": 3220089,
+          "Republican": 187358,
+          "total": 3407447
+        },
+        "gun": {
+          "Democratic": 182302,
+          "Republican": 75685,
+          "total": 257987
+        },
+        "immigra": {
+          "Democratic": 146908,
+          "Republican": 215,
+          "total": 147123
+        },
+        "rights": {
+          "Democratic": 384523,
+          "Republican": 30410,
+          "total": 414933
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 58675,
+          "Republican": 3636,
+          "total": 62311
+        },
+        "capitol": {
+          "Democratic": 364075,
+          "Republican": 3295,
+          "total": 367370
+        },
+        "climate": {
+          "Democratic": 231253,
+          "Republican": 5091,
+          "total": 236344
+        },
+        "covid": {
+          "Democratic": 3220089,
+          "Republican": 187358,
+          "total": 3407447
+        },
+        "gun": {
+          "Democratic": 182302,
+          "Republican": 75685,
+          "total": 257987
+        },
+        "immigra": {
+          "Democratic": 146908,
+          "Republican": 215,
+          "total": 147123
+        },
+        "rights": {
+          "Democratic": 384523,
+          "Republican": 30410,
+          "total": 414933
+        }
+      }
     },
     {
-        "state": "MN",
-        "Democratic": 18535198,
-        "Republican": 808514,
-        "total": 19343712
+      "state": "MN",
+      "Democratic": 16045278,
+      "Republican": 740535,
+      "total": 16785813,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 222545,
+          "Republican": 12163,
+          "total": 234708
+        },
+        "capitol": {
+          "Democratic": 3093010,
+          "Republican": 24534,
+          "total": 3117544
+        },
+        "climate": {
+          "Democratic": 1079481,
+          "Republican": 9742,
+          "total": 1089223
+        },
+        "covid": {
+          "Democratic": 9358031,
+          "Republican": 591670,
+          "total": 9949701
+        },
+        "gun": {
+          "Democratic": 659568,
+          "Republican": 32324,
+          "total": 691892
+        },
+        "immigra": {
+          "Democratic": 546589,
+          "Republican": 26332,
+          "total": 572921
+        },
+        "rights": {
+          "Democratic": 1086054,
+          "Republican": 43770,
+          "total": 1129824
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 222545,
+          "Republican": 12163,
+          "total": 234708
+        },
+        "capitol": {
+          "Democratic": 3093010,
+          "Republican": 24534,
+          "total": 3117544
+        },
+        "climate": {
+          "Democratic": 1079481,
+          "Republican": 9742,
+          "total": 1089223
+        },
+        "covid": {
+          "Democratic": 9358031,
+          "Republican": 591670,
+          "total": 9949701
+        },
+        "gun": {
+          "Democratic": 659568,
+          "Republican": 32324,
+          "total": 691892
+        },
+        "immigra": {
+          "Democratic": 546589,
+          "Republican": 26332,
+          "total": 572921
+        },
+        "rights": {
+          "Democratic": 1086054,
+          "Republican": 43770,
+          "total": 1129824
+        }
+      }
     },
     {
-        "state": "MO",
-        "Democratic": 8106068,
-        "Republican": 1655738,
-        "total": 9761806
+      "state": "MO",
+      "Democratic": 5518698,
+      "Republican": 1526244,
+      "total": 7044942,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 116413,
+          "Republican": 65837,
+          "total": 182250
+        },
+        "capitol": {
+          "Democratic": 510005,
+          "Republican": 6541,
+          "total": 516546
+        },
+        "climate": {
+          "Democratic": 135216,
+          "Republican": 4885,
+          "total": 140101
+        },
+        "covid": {
+          "Democratic": 4204332,
+          "Republican": 939463,
+          "total": 5143795
+        },
+        "gun": {
+          "Democratic": 206178,
+          "Republican": 297953,
+          "total": 504131
+        },
+        "immigra": {
+          "Democratic": 93540,
+          "Republican": 78508,
+          "total": 172048
+        },
+        "rights": {
+          "Democratic": 253014,
+          "Republican": 133057,
+          "total": 386071
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 116413,
+          "Republican": 65837,
+          "total": 182250
+        },
+        "capitol": {
+          "Democratic": 510005,
+          "Republican": 6541,
+          "total": 516546
+        },
+        "climate": {
+          "Democratic": 135216,
+          "Republican": 4885,
+          "total": 140101
+        },
+        "covid": {
+          "Democratic": 4204332,
+          "Republican": 939463,
+          "total": 5143795
+        },
+        "gun": {
+          "Democratic": 206178,
+          "Republican": 297953,
+          "total": 504131
+        },
+        "immigra": {
+          "Democratic": 93540,
+          "Republican": 78508,
+          "total": 172048
+        },
+        "rights": {
+          "Democratic": 253014,
+          "Republican": 133057,
+          "total": 386071
+        }
+      }
     },
     {
-        "state": "MS",
-        "Democratic": 1493838,
-        "Republican": 510949,
-        "total": 2004787
+      "state": "MS",
+      "Democratic": 522182,
+      "Republican": 518954,
+      "total": 1041136,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 4,
+          "Republican": 56,
+          "total": 60
+        },
+        "capitol": {
+          "Democratic": 180567,
+          "Republican": 47382,
+          "total": 227949
+        },
+        "covid": {
+          "Democratic": 259587,
+          "Republican": 461078,
+          "total": 720665
+        },
+        "gun": {
+          "Democratic": 5262,
+          "Republican": 2110,
+          "total": 7372
+        },
+        "immigra": {
+          "Democratic": 33939,
+          "Republican": 2835,
+          "total": 36774
+        },
+        "rights": {
+          "Democratic": 42823,
+          "Republican": 5493,
+          "total": 48316
+        },
+        "climate": {
+          "Democratic": 0,
+          "Republican": 0,
+          "total": 0
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 4,
+          "Republican": 56,
+          "total": 60
+        },
+        "capitol": {
+          "Democratic": 180567,
+          "Republican": 47382,
+          "total": 227949
+        },
+        "covid": {
+          "Democratic": 259587,
+          "Republican": 461078,
+          "total": 720665
+        },
+        "gun": {
+          "Democratic": 5262,
+          "Republican": 2110,
+          "total": 7372
+        },
+        "immigra": {
+          "Democratic": 33939,
+          "Republican": 2835,
+          "total": 36774
+        },
+        "rights": {
+          "Democratic": 42823,
+          "Republican": 5493,
+          "total": 48316
+        },
+        "climate": {
+          "Democratic": 0,
+          "Republican": 0,
+          "total": 0
+        }
+      }
     },
     {
-        "state": "MT",
-        "Democratic": 2819205,
-        "Republican": 468421,
-        "total": 3287626
+      "state": "MT",
+      "Democratic": 2228554,
+      "Republican": 468412,
+      "total": 2696966,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 70509,
+          "Republican": 1,
+          "total": 70510
+        },
+        "capitol": {
+          "Democratic": 1002547,
+          "Republican": 22994,
+          "total": 1025541
+        },
+        "climate": {
+          "Democratic": 64763,
+          "Republican": 1494,
+          "total": 66257
+        },
+        "covid": {
+          "Democratic": 819182,
+          "Republican": 367198,
+          "total": 1186380
+        },
+        "gun": {
+          "Democratic": 68641,
+          "Republican": 31493,
+          "total": 100134
+        },
+        "immigra": {
+          "Democratic": 43404,
+          "Republican": 23,
+          "total": 43427
+        },
+        "rights": {
+          "Democratic": 159508,
+          "Republican": 45209,
+          "total": 204717
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 70509,
+          "Republican": 1,
+          "total": 70510
+        },
+        "capitol": {
+          "Democratic": 1002547,
+          "Republican": 22994,
+          "total": 1025541
+        },
+        "climate": {
+          "Democratic": 64763,
+          "Republican": 1494,
+          "total": 66257
+        },
+        "covid": {
+          "Democratic": 819182,
+          "Republican": 367198,
+          "total": 1186380
+        },
+        "gun": {
+          "Democratic": 68641,
+          "Republican": 31493,
+          "total": 100134
+        },
+        "immigra": {
+          "Democratic": 43404,
+          "Republican": 23,
+          "total": 43427
+        },
+        "rights": {
+          "Democratic": 159508,
+          "Republican": 45209,
+          "total": 204717
+        }
+      }
     },
     {
-        "state": "NC",
-        "Democratic": 6575222,
-        "Republican": 3693032,
-        "total": 10268254
+      "state": "NC",
+      "Democratic": 5443757,
+      "Republican": 2912566,
+      "total": 8356323,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 63020,
+          "Republican": 23357,
+          "total": 86377
+        },
+        "capitol": {
+          "Democratic": 1632708,
+          "Republican": 138485,
+          "total": 1771193
+        },
+        "climate": {
+          "Democratic": 337638,
+          "Republican": 92605,
+          "total": 430243
+        },
+        "covid": {
+          "Democratic": 2739670,
+          "Republican": 1800130,
+          "total": 4539800
+        },
+        "gun": {
+          "Democratic": 221056,
+          "Republican": 326949,
+          "total": 548005
+        },
+        "immigra": {
+          "Democratic": 126370,
+          "Republican": 118,
+          "total": 126488
+        },
+        "rights": {
+          "Democratic": 323295,
+          "Republican": 530922,
+          "total": 854217
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 63020,
+          "Republican": 23357,
+          "total": 86377
+        },
+        "capitol": {
+          "Democratic": 1632708,
+          "Republican": 138485,
+          "total": 1771193
+        },
+        "climate": {
+          "Democratic": 337638,
+          "Republican": 92605,
+          "total": 430243
+        },
+        "covid": {
+          "Democratic": 2739670,
+          "Republican": 1800130,
+          "total": 4539800
+        },
+        "gun": {
+          "Democratic": 221056,
+          "Republican": 326949,
+          "total": 548005
+        },
+        "immigra": {
+          "Democratic": 126370,
+          "Republican": 118,
+          "total": 126488
+        },
+        "rights": {
+          "Democratic": 323295,
+          "Republican": 530922,
+          "total": 854217
+        }
+      }
     },
     {
-        "state": "ND",
-        "Democratic": 297978,
-        "Republican": 51646,
-        "total": 349624
+      "state": "ND",
+      "Democratic": 301802,
+      "Republican": 51565,
+      "total": 353367,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 4680,
+          "Republican": 3316,
+          "total": 7996
+        },
+        "capitol": {
+          "Democratic": 72,
+          "Republican": 2932,
+          "total": 3004
+        },
+        "climate": {
+          "Democratic": 6663,
+          "Republican": 7,
+          "total": 6670
+        },
+        "covid": {
+          "Democratic": 276252,
+          "Republican": 17276,
+          "total": 293528
+        },
+        "gun": {
+          "Democratic": 362,
+          "Republican": 27606,
+          "total": 27968
+        },
+        "immigra": {
+          "Democratic": 397,
+          "Republican": 0,
+          "total": 397
+        },
+        "rights": {
+          "Democratic": 13376,
+          "Republican": 428,
+          "total": 13804
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 4680,
+          "Republican": 3316,
+          "total": 7996
+        },
+        "capitol": {
+          "Democratic": 72,
+          "Republican": 2932,
+          "total": 3004
+        },
+        "climate": {
+          "Democratic": 6663,
+          "Republican": 7,
+          "total": 6670
+        },
+        "covid": {
+          "Democratic": 276252,
+          "Republican": 17276,
+          "total": 293528
+        },
+        "gun": {
+          "Democratic": 362,
+          "Republican": 27606,
+          "total": 27968
+        },
+        "immigra": {
+          "Democratic": 397,
+          "Republican": 0,
+          "total": 397
+        },
+        "rights": {
+          "Democratic": 13376,
+          "Republican": 428,
+          "total": 13804
+        }
+      }
     },
     {
-        "state": "NE",
-        "Democratic": 1553529,
-        "Republican": 120,
-        "total": 1553649
+      "state": "NE",
+      "Democratic": 1558544,
+      "Republican": 120,
+      "total": 1558664,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 2938,
+          "Republican": 0,
+          "total": 2938
+        },
+        "capitol": {
+          "Democratic": 9730,
+          "Republican": 0,
+          "total": 9730
+        },
+        "climate": {
+          "Democratic": 63967,
+          "Republican": 0,
+          "total": 63967
+        },
+        "covid": {
+          "Democratic": 1460194,
+          "Republican": 120,
+          "total": 1460314
+        },
+        "gun": {
+          "Democratic": 6240,
+          "Republican": 0,
+          "total": 6240
+        },
+        "immigra": {
+          "Democratic": 4811,
+          "Republican": 0,
+          "total": 4811
+        },
+        "rights": {
+          "Democratic": 10664,
+          "Republican": 0,
+          "total": 10664
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 2938,
+          "Republican": 0,
+          "total": 2938
+        },
+        "capitol": {
+          "Democratic": 9730,
+          "Republican": 0,
+          "total": 9730
+        },
+        "climate": {
+          "Democratic": 63967,
+          "Republican": 0,
+          "total": 63967
+        },
+        "covid": {
+          "Democratic": 1460194,
+          "Republican": 120,
+          "total": 1460314
+        },
+        "gun": {
+          "Democratic": 6240,
+          "Republican": 0,
+          "total": 6240
+        },
+        "immigra": {
+          "Democratic": 4811,
+          "Republican": 0,
+          "total": 4811
+        },
+        "rights": {
+          "Democratic": 10664,
+          "Republican": 0,
+          "total": 10664
+        }
+      }
     },
     {
-        "state": "NH",
-        "Democratic": 43774957,
-        "Republican": 1108722,
-        "total": 44883679
+      "state": "NH",
+      "Democratic": 38717038,
+      "Republican": 948553,
+      "total": 39665591,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 712586,
+          "Republican": 34724,
+          "total": 747310
+        },
+        "capitol": {
+          "Democratic": 6027978,
+          "Republican": 63514,
+          "total": 6091492
+        },
+        "climate": {
+          "Democratic": 1364142,
+          "Republican": 23937,
+          "total": 1388079
+        },
+        "covid": {
+          "Democratic": 25538470,
+          "Republican": 417511,
+          "total": 25955981
+        },
+        "gun": {
+          "Democratic": 1824773,
+          "Republican": 192339,
+          "total": 2017112
+        },
+        "immigra": {
+          "Democratic": 956347,
+          "Republican": 81844,
+          "total": 1038191
+        },
+        "rights": {
+          "Democratic": 2292742,
+          "Republican": 134684,
+          "total": 2427426
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 712586,
+          "Republican": 34724,
+          "total": 747310
+        },
+        "capitol": {
+          "Democratic": 6027978,
+          "Republican": 63514,
+          "total": 6091492
+        },
+        "climate": {
+          "Democratic": 1364142,
+          "Republican": 23937,
+          "total": 1388079
+        },
+        "covid": {
+          "Democratic": 25538470,
+          "Republican": 417511,
+          "total": 25955981
+        },
+        "gun": {
+          "Democratic": 1824773,
+          "Republican": 192339,
+          "total": 2017112
+        },
+        "immigra": {
+          "Democratic": 956347,
+          "Republican": 81844,
+          "total": 1038191
+        },
+        "rights": {
+          "Democratic": 2292742,
+          "Republican": 134684,
+          "total": 2427426
+        }
+      }
     },
     {
-        "state": "NJ",
-        "Democratic": 1198696,
-        "Republican": 162722,
-        "total": 1361418
+      "state": "NJ",
+      "Democratic": 644771,
+      "Republican": 165475,
+      "total": 810246,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 157,
+          "Republican": 29,
+          "total": 186
+        },
+        "capitol": {
+          "Democratic": 22816,
+          "Republican": 6,
+          "total": 22822
+        },
+        "climate": {
+          "Democratic": 8847,
+          "Republican": 3085,
+          "total": 11932
+        },
+        "covid": {
+          "Democratic": 449417,
+          "Republican": 155086,
+          "total": 604503
+        },
+        "gun": {
+          "Democratic": 66957,
+          "Republican": 312,
+          "total": 67269
+        },
+        "immigra": {
+          "Democratic": 878,
+          "Republican": 118,
+          "total": 996
+        },
+        "rights": {
+          "Democratic": 95699,
+          "Republican": 6839,
+          "total": 102538
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 157,
+          "Republican": 29,
+          "total": 186
+        },
+        "capitol": {
+          "Democratic": 22816,
+          "Republican": 6,
+          "total": 22822
+        },
+        "climate": {
+          "Democratic": 8847,
+          "Republican": 3085,
+          "total": 11932
+        },
+        "covid": {
+          "Democratic": 449417,
+          "Republican": 155086,
+          "total": 604503
+        },
+        "gun": {
+          "Democratic": 66957,
+          "Republican": 312,
+          "total": 67269
+        },
+        "immigra": {
+          "Democratic": 878,
+          "Republican": 118,
+          "total": 996
+        },
+        "rights": {
+          "Democratic": 95699,
+          "Republican": 6839,
+          "total": 102538
+        }
+      }
     },
     {
-        "state": "NM",
-        "Democratic": 25246174,
-        "Republican": 14520,
-        "total": 25260694
+      "state": "NM",
+      "Democratic": 23114621,
+      "Republican": 14564,
+      "total": 23129185,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 776671,
+          "Republican": 2088,
+          "total": 778759
+        },
+        "capitol": {
+          "Democratic": 3286527,
+          "Republican": 10,
+          "total": 3286537
+        },
+        "climate": {
+          "Democratic": 772070,
+          "Republican": 0,
+          "total": 772070
+        },
+        "covid": {
+          "Democratic": 13754156,
+          "Republican": 2274,
+          "total": 13756430
+        },
+        "gun": {
+          "Democratic": 2078371,
+          "Republican": 9738,
+          "total": 2088109
+        },
+        "immigra": {
+          "Democratic": 634275,
+          "Republican": 4,
+          "total": 634279
+        },
+        "rights": {
+          "Democratic": 1812551,
+          "Republican": 450,
+          "total": 1813001
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 776671,
+          "Republican": 2088,
+          "total": 778759
+        },
+        "capitol": {
+          "Democratic": 3286527,
+          "Republican": 10,
+          "total": 3286537
+        },
+        "climate": {
+          "Democratic": 772070,
+          "Republican": 0,
+          "total": 772070
+        },
+        "covid": {
+          "Democratic": 13754156,
+          "Republican": 2274,
+          "total": 13756430
+        },
+        "gun": {
+          "Democratic": 2078371,
+          "Republican": 9738,
+          "total": 2088109
+        },
+        "immigra": {
+          "Democratic": 634275,
+          "Republican": 4,
+          "total": 634279
+        },
+        "rights": {
+          "Democratic": 1812551,
+          "Republican": 450,
+          "total": 1813001
+        }
+      }
     },
     {
-        "state": "NV",
-        "Democratic": 5048578,
-        "Republican": 232595,
-        "total": 5281173
+      "state": "NV",
+      "Democratic": 4541368,
+      "Republican": 200826,
+      "total": 4742194,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 215390,
+          "Republican": 21,
+          "total": 215411
+        },
+        "capitol": {
+          "Democratic": 1352337,
+          "Republican": 12758,
+          "total": 1365095
+        },
+        "climate": {
+          "Democratic": 147230,
+          "Republican": 5,
+          "total": 147235
+        },
+        "covid": {
+          "Democratic": 2424476,
+          "Republican": 127500,
+          "total": 2551976
+        },
+        "gun": {
+          "Democratic": 178138,
+          "Republican": 44183,
+          "total": 222321
+        },
+        "immigra": {
+          "Democratic": 72304,
+          "Republican": 5452,
+          "total": 77756
+        },
+        "rights": {
+          "Democratic": 151493,
+          "Republican": 10907,
+          "total": 162400
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 215390,
+          "Republican": 21,
+          "total": 215411
+        },
+        "capitol": {
+          "Democratic": 1352337,
+          "Republican": 12758,
+          "total": 1365095
+        },
+        "climate": {
+          "Democratic": 147230,
+          "Republican": 5,
+          "total": 147235
+        },
+        "covid": {
+          "Democratic": 2424476,
+          "Republican": 127500,
+          "total": 2551976
+        },
+        "gun": {
+          "Democratic": 178138,
+          "Republican": 44183,
+          "total": 222321
+        },
+        "immigra": {
+          "Democratic": 72304,
+          "Republican": 5452,
+          "total": 77756
+        },
+        "rights": {
+          "Democratic": 151493,
+          "Republican": 10907,
+          "total": 162400
+        }
+      }
     },
     {
-        "state": "NY",
-        "Democratic": 15815791,
-        "Republican": 825472,
-        "total": 16641263
+      "state": "NY",
+      "Democratic": 12778735,
+      "Republican": 847520,
+      "total": 13626255,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 306445,
+          "Republican": 1515,
+          "total": 307960
+        },
+        "capitol": {
+          "Democratic": 958884,
+          "Republican": 44668,
+          "total": 1003552
+        },
+        "climate": {
+          "Democratic": 542214,
+          "Republican": 11722,
+          "total": 553936
+        },
+        "covid": {
+          "Democratic": 8039043,
+          "Republican": 576270,
+          "total": 8615313
+        },
+        "gun": {
+          "Democratic": 796917,
+          "Republican": 92842,
+          "total": 889759
+        },
+        "immigra": {
+          "Democratic": 618146,
+          "Republican": 79401,
+          "total": 697547
+        },
+        "rights": {
+          "Democratic": 1517086,
+          "Republican": 41102,
+          "total": 1558188
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 306445,
+          "Republican": 1515,
+          "total": 307960
+        },
+        "capitol": {
+          "Democratic": 958884,
+          "Republican": 44668,
+          "total": 1003552
+        },
+        "climate": {
+          "Democratic": 542214,
+          "Republican": 11722,
+          "total": 553936
+        },
+        "covid": {
+          "Democratic": 8039043,
+          "Republican": 576270,
+          "total": 8615313
+        },
+        "gun": {
+          "Democratic": 796917,
+          "Republican": 92842,
+          "total": 889759
+        },
+        "immigra": {
+          "Democratic": 618146,
+          "Republican": 79401,
+          "total": 697547
+        },
+        "rights": {
+          "Democratic": 1517086,
+          "Republican": 41102,
+          "total": 1558188
+        }
+      }
     },
     {
-        "state": "OH",
-        "Democratic": 4881754,
-        "Republican": 673104,
-        "total": 5554858
+      "state": "OH",
+      "Democratic": 3743333,
+      "Republican": 674633,
+      "total": 4417966,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 53331,
+          "Republican": 1207,
+          "total": 54538
+        },
+        "capitol": {
+          "Democratic": 902244,
+          "Republican": 22042,
+          "total": 924286
+        },
+        "climate": {
+          "Democratic": 111524,
+          "Republican": 594,
+          "total": 112118
+        },
+        "covid": {
+          "Democratic": 2072360,
+          "Republican": 515854,
+          "total": 2588214
+        },
+        "gun": {
+          "Democratic": 160496,
+          "Republican": 95805,
+          "total": 256301
+        },
+        "immigra": {
+          "Democratic": 113886,
+          "Republican": 30902,
+          "total": 144788
+        },
+        "rights": {
+          "Democratic": 329492,
+          "Republican": 8229,
+          "total": 337721
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 53331,
+          "Republican": 1207,
+          "total": 54538
+        },
+        "capitol": {
+          "Democratic": 902244,
+          "Republican": 22042,
+          "total": 924286
+        },
+        "climate": {
+          "Democratic": 111524,
+          "Republican": 594,
+          "total": 112118
+        },
+        "covid": {
+          "Democratic": 2072360,
+          "Republican": 515854,
+          "total": 2588214
+        },
+        "gun": {
+          "Democratic": 160496,
+          "Republican": 95805,
+          "total": 256301
+        },
+        "immigra": {
+          "Democratic": 113886,
+          "Republican": 30902,
+          "total": 144788
+        },
+        "rights": {
+          "Democratic": 329492,
+          "Republican": 8229,
+          "total": 337721
+        }
+      }
     },
     {
-        "state": "OK",
-        "Democratic": 4528333,
-        "Republican": 521300,
-        "total": 5049633
+      "state": "OK",
+      "Democratic": 2844782,
+      "Republican": 485689,
+      "total": 3330471,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 44763,
+          "Republican": 11997,
+          "total": 56760
+        },
+        "capitol": {
+          "Democratic": 311291,
+          "Republican": 57849,
+          "total": 369140
+        },
+        "climate": {
+          "Democratic": 96806,
+          "Republican": 6183,
+          "total": 102989
+        },
+        "covid": {
+          "Democratic": 1852914,
+          "Republican": 355237,
+          "total": 2208151
+        },
+        "gun": {
+          "Democratic": 233836,
+          "Republican": 31414,
+          "total": 265250
+        },
+        "immigra": {
+          "Democratic": 39225,
+          "Republican": 11215,
+          "total": 50440
+        },
+        "rights": {
+          "Democratic": 265947,
+          "Republican": 11794,
+          "total": 277741
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 44763,
+          "Republican": 11997,
+          "total": 56760
+        },
+        "capitol": {
+          "Democratic": 311291,
+          "Republican": 57849,
+          "total": 369140
+        },
+        "climate": {
+          "Democratic": 96806,
+          "Republican": 6183,
+          "total": 102989
+        },
+        "covid": {
+          "Democratic": 1852914,
+          "Republican": 355237,
+          "total": 2208151
+        },
+        "gun": {
+          "Democratic": 233836,
+          "Republican": 31414,
+          "total": 265250
+        },
+        "immigra": {
+          "Democratic": 39225,
+          "Republican": 11215,
+          "total": 50440
+        },
+        "rights": {
+          "Democratic": 265947,
+          "Republican": 11794,
+          "total": 277741
+        }
+      }
     },
     {
-        "state": "OR",
-        "Democratic": 2236172,
-        "Republican": 1916766,
-        "total": 4152938
+      "state": "OR",
+      "Democratic": 2226663,
+      "Republican": 1898923,
+      "total": 4125586,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 26421,
+          "Republican": 49663,
+          "total": 76084
+        },
+        "capitol": {
+          "Democratic": 264960,
+          "Republican": 45526,
+          "total": 310486
+        },
+        "climate": {
+          "Democratic": 211211,
+          "Republican": 38174,
+          "total": 249385
+        },
+        "covid": {
+          "Democratic": 1326391,
+          "Republican": 1626955,
+          "total": 2953346
+        },
+        "gun": {
+          "Democratic": 52016,
+          "Republican": 47809,
+          "total": 99825
+        },
+        "immigra": {
+          "Democratic": 174270,
+          "Republican": 62882,
+          "total": 237152
+        },
+        "rights": {
+          "Democratic": 171394,
+          "Republican": 27914,
+          "total": 199308
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 26421,
+          "Republican": 49663,
+          "total": 76084
+        },
+        "capitol": {
+          "Democratic": 264960,
+          "Republican": 45526,
+          "total": 310486
+        },
+        "climate": {
+          "Democratic": 211211,
+          "Republican": 38174,
+          "total": 249385
+        },
+        "covid": {
+          "Democratic": 1326391,
+          "Republican": 1626955,
+          "total": 2953346
+        },
+        "gun": {
+          "Democratic": 52016,
+          "Republican": 47809,
+          "total": 99825
+        },
+        "immigra": {
+          "Democratic": 174270,
+          "Republican": 62882,
+          "total": 237152
+        },
+        "rights": {
+          "Democratic": 171394,
+          "Republican": 27914,
+          "total": 199308
+        }
+      }
     },
     {
-        "state": "PA",
-        "Democratic": 9512270,
-        "Republican": 1003143,
-        "total": 10515413
+      "state": "PA",
+      "Democratic": 7127633,
+      "Republican": 983211,
+      "total": 8110844,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 72532,
+          "Republican": 9180,
+          "total": 81712
+        },
+        "capitol": {
+          "Democratic": 771689,
+          "Republican": 35626,
+          "total": 807315
+        },
+        "climate": {
+          "Democratic": 229752,
+          "Republican": 376,
+          "total": 230128
+        },
+        "covid": {
+          "Democratic": 5073342,
+          "Republican": 869302,
+          "total": 5942644
+        },
+        "gun": {
+          "Democratic": 213982,
+          "Republican": 28439,
+          "total": 242421
+        },
+        "immigra": {
+          "Democratic": 158034,
+          "Republican": 20477,
+          "total": 178511
+        },
+        "rights": {
+          "Democratic": 608302,
+          "Republican": 19811,
+          "total": 628113
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 72532,
+          "Republican": 9180,
+          "total": 81712
+        },
+        "capitol": {
+          "Democratic": 771689,
+          "Republican": 35626,
+          "total": 807315
+        },
+        "climate": {
+          "Democratic": 229752,
+          "Republican": 376,
+          "total": 230128
+        },
+        "covid": {
+          "Democratic": 5073342,
+          "Republican": 869302,
+          "total": 5942644
+        },
+        "gun": {
+          "Democratic": 213982,
+          "Republican": 28439,
+          "total": 242421
+        },
+        "immigra": {
+          "Democratic": 158034,
+          "Republican": 20477,
+          "total": 178511
+        },
+        "rights": {
+          "Democratic": 608302,
+          "Republican": 19811,
+          "total": 628113
+        }
+      }
     },
     {
-        "state": "RI",
-        "Democratic": 3909197,
-        "Republican": 824681,
-        "total": 4733878
+      "state": "RI",
+      "Democratic": 3693644,
+      "Republican": 841481,
+      "total": 4535125,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 71449,
+          "Republican": 15301,
+          "total": 86750
+        },
+        "capitol": {
+          "Democratic": 904445,
+          "Republican": 57190,
+          "total": 961635
+        },
+        "climate": {
+          "Democratic": 259444,
+          "Republican": 33001,
+          "total": 292445
+        },
+        "covid": {
+          "Democratic": 2063072,
+          "Republican": 541865,
+          "total": 2604937
+        },
+        "gun": {
+          "Democratic": 99689,
+          "Republican": 51163,
+          "total": 150852
+        },
+        "immigra": {
+          "Democratic": 97412,
+          "Republican": 86762,
+          "total": 184174
+        },
+        "rights": {
+          "Democratic": 198133,
+          "Republican": 56199,
+          "total": 254332
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 71449,
+          "Republican": 15301,
+          "total": 86750
+        },
+        "capitol": {
+          "Democratic": 904445,
+          "Republican": 57190,
+          "total": 961635
+        },
+        "climate": {
+          "Democratic": 259444,
+          "Republican": 33001,
+          "total": 292445
+        },
+        "covid": {
+          "Democratic": 2063072,
+          "Republican": 541865,
+          "total": 2604937
+        },
+        "gun": {
+          "Democratic": 99689,
+          "Republican": 51163,
+          "total": 150852
+        },
+        "immigra": {
+          "Democratic": 97412,
+          "Republican": 86762,
+          "total": 184174
+        },
+        "rights": {
+          "Democratic": 198133,
+          "Republican": 56199,
+          "total": 254332
+        }
+      }
     },
     {
-        "state": "SC",
-        "Democratic": 5324240,
-        "Republican": 846028,
-        "total": 6170268
+      "state": "SC",
+      "Democratic": 5048870,
+      "Republican": 795728,
+      "total": 5844598,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 32594,
+          "Republican": 6165,
+          "total": 38759
+        },
+        "capitol": {
+          "Democratic": 789699,
+          "Republican": 85020,
+          "total": 874719
+        },
+        "climate": {
+          "Democratic": 94402,
+          "Republican": 1680,
+          "total": 96082
+        },
+        "covid": {
+          "Democratic": 3202902,
+          "Republican": 451923,
+          "total": 3654825
+        },
+        "gun": {
+          "Democratic": 338893,
+          "Republican": 199497,
+          "total": 538390
+        },
+        "immigra": {
+          "Democratic": 19700,
+          "Republican": 31347,
+          "total": 51047
+        },
+        "rights": {
+          "Democratic": 570680,
+          "Republican": 20096,
+          "total": 590776
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 32594,
+          "Republican": 6165,
+          "total": 38759
+        },
+        "capitol": {
+          "Democratic": 789699,
+          "Republican": 85020,
+          "total": 874719
+        },
+        "climate": {
+          "Democratic": 94402,
+          "Republican": 1680,
+          "total": 96082
+        },
+        "covid": {
+          "Democratic": 3202902,
+          "Republican": 451923,
+          "total": 3654825
+        },
+        "gun": {
+          "Democratic": 338893,
+          "Republican": 199497,
+          "total": 538390
+        },
+        "immigra": {
+          "Democratic": 19700,
+          "Republican": 31347,
+          "total": 51047
+        },
+        "rights": {
+          "Democratic": 570680,
+          "Republican": 20096,
+          "total": 590776
+        }
+      }
     },
     {
-        "state": "SD",
-        "Democratic": 1511881,
-        "Republican": 427283,
-        "total": 1939164
+      "state": "SD",
+      "Democratic": 1525366,
+      "Republican": 428121,
+      "total": 1953487,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 43143,
+          "Republican": 3651,
+          "total": 46794
+        },
+        "capitol": {
+          "Democratic": 54444,
+          "Republican": 0,
+          "total": 54444
+        },
+        "climate": {
+          "Democratic": 106303,
+          "Republican": 64,
+          "total": 106367
+        },
+        "covid": {
+          "Democratic": 1084302,
+          "Republican": 411231,
+          "total": 1495533
+        },
+        "gun": {
+          "Democratic": 130086,
+          "Republican": 1464,
+          "total": 131550
+        },
+        "immigra": {
+          "Democratic": 23921,
+          "Republican": 5,
+          "total": 23926
+        },
+        "rights": {
+          "Democratic": 83167,
+          "Republican": 11706,
+          "total": 94873
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 43143,
+          "Republican": 3651,
+          "total": 46794
+        },
+        "capitol": {
+          "Democratic": 54444,
+          "Republican": 0,
+          "total": 54444
+        },
+        "climate": {
+          "Democratic": 106303,
+          "Republican": 64,
+          "total": 106367
+        },
+        "covid": {
+          "Democratic": 1084302,
+          "Republican": 411231,
+          "total": 1495533
+        },
+        "gun": {
+          "Democratic": 130086,
+          "Republican": 1464,
+          "total": 131550
+        },
+        "immigra": {
+          "Democratic": 23921,
+          "Republican": 5,
+          "total": 23926
+        },
+        "rights": {
+          "Democratic": 83167,
+          "Republican": 11706,
+          "total": 94873
+        }
+      }
     },
     {
-        "state": "TN",
-        "Democratic": 8919907,
-        "Republican": 2155406,
-        "total": 11075313
+      "state": "TN",
+      "Democratic": 6949282,
+      "Republican": 1924202,
+      "total": 8873484,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 88745,
+          "Republican": 82441,
+          "total": 171186
+        },
+        "capitol": {
+          "Democratic": 778033,
+          "Republican": 47767,
+          "total": 825800
+        },
+        "climate": {
+          "Democratic": 302736,
+          "Republican": 22328,
+          "total": 325064
+        },
+        "covid": {
+          "Democratic": 4386596,
+          "Republican": 1463690,
+          "total": 5850286
+        },
+        "gun": {
+          "Democratic": 441319,
+          "Republican": 191527,
+          "total": 632846
+        },
+        "immigra": {
+          "Democratic": 244689,
+          "Republican": 37168,
+          "total": 281857
+        },
+        "rights": {
+          "Democratic": 707164,
+          "Republican": 79281,
+          "total": 786445
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 88745,
+          "Republican": 82441,
+          "total": 171186
+        },
+        "capitol": {
+          "Democratic": 778033,
+          "Republican": 47767,
+          "total": 825800
+        },
+        "climate": {
+          "Democratic": 302736,
+          "Republican": 22328,
+          "total": 325064
+        },
+        "covid": {
+          "Democratic": 4386596,
+          "Republican": 1463690,
+          "total": 5850286
+        },
+        "gun": {
+          "Democratic": 441319,
+          "Republican": 191527,
+          "total": 632846
+        },
+        "immigra": {
+          "Democratic": 244689,
+          "Republican": 37168,
+          "total": 281857
+        },
+        "rights": {
+          "Democratic": 707164,
+          "Republican": 79281,
+          "total": 786445
+        }
+      }
     },
     {
-        "state": "TX",
-        "Democratic": 16642987,
-        "Republican": 2012186,
-        "total": 18655173
+      "state": "TX",
+      "Democratic": 13251211,
+      "Republican": 1933897,
+      "total": 15185108,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 250937,
+          "Republican": 101251,
+          "total": 352188
+        },
+        "capitol": {
+          "Democratic": 545090,
+          "Republican": 42213,
+          "total": 587303
+        },
+        "climate": {
+          "Democratic": 509832,
+          "Republican": 39542,
+          "total": 549374
+        },
+        "covid": {
+          "Democratic": 8908089,
+          "Republican": 1381028,
+          "total": 10289117
+        },
+        "gun": {
+          "Democratic": 1053855,
+          "Republican": 208495,
+          "total": 1262350
+        },
+        "immigra": {
+          "Democratic": 583890,
+          "Republican": 80565,
+          "total": 664455
+        },
+        "rights": {
+          "Democratic": 1399518,
+          "Republican": 80803,
+          "total": 1480321
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 250937,
+          "Republican": 101251,
+          "total": 352188
+        },
+        "capitol": {
+          "Democratic": 545090,
+          "Republican": 42213,
+          "total": 587303
+        },
+        "climate": {
+          "Democratic": 509832,
+          "Republican": 39542,
+          "total": 549374
+        },
+        "covid": {
+          "Democratic": 8908089,
+          "Republican": 1381028,
+          "total": 10289117
+        },
+        "gun": {
+          "Democratic": 1053855,
+          "Republican": 208495,
+          "total": 1262350
+        },
+        "immigra": {
+          "Democratic": 583890,
+          "Republican": 80565,
+          "total": 664455
+        },
+        "rights": {
+          "Democratic": 1399518,
+          "Republican": 80803,
+          "total": 1480321
+        }
+      }
     },
     {
-        "state": "UT",
-        "Democratic": 3996978,
-        "Republican": 178209,
-        "total": 4175187
+      "state": "UT",
+      "Democratic": 3196235,
+      "Republican": 130747,
+      "total": 3326982,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 53036,
+          "Republican": 756,
+          "total": 53792
+        },
+        "capitol": {
+          "Democratic": 96510,
+          "Republican": 31910,
+          "total": 128420
+        },
+        "climate": {
+          "Democratic": 189365,
+          "Republican": 787,
+          "total": 190152
+        },
+        "covid": {
+          "Democratic": 2262030,
+          "Republican": 83081,
+          "total": 2345111
+        },
+        "gun": {
+          "Democratic": 137851,
+          "Republican": 276,
+          "total": 138127
+        },
+        "immigra": {
+          "Democratic": 215283,
+          "Republican": 7212,
+          "total": 222495
+        },
+        "rights": {
+          "Democratic": 242160,
+          "Republican": 6725,
+          "total": 248885
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 53036,
+          "Republican": 756,
+          "total": 53792
+        },
+        "capitol": {
+          "Democratic": 96510,
+          "Republican": 31910,
+          "total": 128420
+        },
+        "climate": {
+          "Democratic": 189365,
+          "Republican": 787,
+          "total": 190152
+        },
+        "covid": {
+          "Democratic": 2262030,
+          "Republican": 83081,
+          "total": 2345111
+        },
+        "gun": {
+          "Democratic": 137851,
+          "Republican": 276,
+          "total": 138127
+        },
+        "immigra": {
+          "Democratic": 215283,
+          "Republican": 7212,
+          "total": 222495
+        },
+        "rights": {
+          "Democratic": 242160,
+          "Republican": 6725,
+          "total": 248885
+        }
+      }
     },
     {
-        "state": "VA",
-        "Democratic": 10419897,
-        "Republican": 198778,
-        "total": 10618675
+      "state": "VA",
+      "Democratic": 6733924,
+      "Republican": 154431,
+      "total": 6888355,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 68484,
+          "Republican": 2975,
+          "total": 71459
+        },
+        "capitol": {
+          "Democratic": 283705,
+          "Republican": 20056,
+          "total": 303761
+        },
+        "climate": {
+          "Democratic": 407004,
+          "Republican": 1443,
+          "total": 408447
+        },
+        "covid": {
+          "Democratic": 4391427,
+          "Republican": 101373,
+          "total": 4492800
+        },
+        "gun": {
+          "Democratic": 690311,
+          "Republican": 21942,
+          "total": 712253
+        },
+        "immigra": {
+          "Democratic": 269632,
+          "Republican": 3066,
+          "total": 272698
+        },
+        "rights": {
+          "Democratic": 623361,
+          "Republican": 3576,
+          "total": 626937
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 68484,
+          "Republican": 2975,
+          "total": 71459
+        },
+        "capitol": {
+          "Democratic": 283705,
+          "Republican": 20056,
+          "total": 303761
+        },
+        "climate": {
+          "Democratic": 407004,
+          "Republican": 1443,
+          "total": 408447
+        },
+        "covid": {
+          "Democratic": 4391427,
+          "Republican": 101373,
+          "total": 4492800
+        },
+        "gun": {
+          "Democratic": 690311,
+          "Republican": 21942,
+          "total": 712253
+        },
+        "immigra": {
+          "Democratic": 269632,
+          "Republican": 3066,
+          "total": 272698
+        },
+        "rights": {
+          "Democratic": 623361,
+          "Republican": 3576,
+          "total": 626937
+        }
+      }
     },
     {
-        "state": "VT",
-        "Democratic": 1109588,
-        "Republican": 10393,
-        "total": 1119981
+      "state": "VT",
+      "Democratic": 616644,
+      "Republican": 10393,
+      "total": 627037,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 323,
+          "Republican": 0,
+          "total": 323
+        },
+        "capitol": {
+          "Democratic": 14221,
+          "Republican": 0,
+          "total": 14221
+        },
+        "climate": {
+          "Democratic": 13204,
+          "Republican": 0,
+          "total": 13204
+        },
+        "covid": {
+          "Democratic": 412628,
+          "Republican": 5710,
+          "total": 418338
+        },
+        "gun": {
+          "Democratic": 5207,
+          "Republican": 0,
+          "total": 5207
+        },
+        "immigra": {
+          "Democratic": 2157,
+          "Republican": 0,
+          "total": 2157
+        },
+        "rights": {
+          "Democratic": 168904,
+          "Republican": 4683,
+          "total": 173587
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 323,
+          "Republican": 0,
+          "total": 323
+        },
+        "capitol": {
+          "Democratic": 14221,
+          "Republican": 0,
+          "total": 14221
+        },
+        "climate": {
+          "Democratic": 13204,
+          "Republican": 0,
+          "total": 13204
+        },
+        "covid": {
+          "Democratic": 412628,
+          "Republican": 5710,
+          "total": 418338
+        },
+        "gun": {
+          "Democratic": 5207,
+          "Republican": 0,
+          "total": 5207
+        },
+        "immigra": {
+          "Democratic": 2157,
+          "Republican": 0,
+          "total": 2157
+        },
+        "rights": {
+          "Democratic": 168904,
+          "Republican": 4683,
+          "total": 173587
+        }
+      }
     },
     {
-        "state": "WA",
-        "Democratic": 3705818,
-        "Republican": 113017,
-        "total": 3818835
+      "state": "WA",
+      "Democratic": 3559264,
+      "Republican": 112932,
+      "total": 3672196,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 62348,
+          "Republican": 0,
+          "total": 62348
+        },
+        "capitol": {
+          "Democratic": 217424,
+          "Republican": 16149,
+          "total": 233573
+        },
+        "climate": {
+          "Democratic": 680551,
+          "Republican": 166,
+          "total": 680717
+        },
+        "covid": {
+          "Democratic": 2159549,
+          "Republican": 17633,
+          "total": 2177182
+        },
+        "gun": {
+          "Democratic": 55555,
+          "Republican": 74799,
+          "total": 130354
+        },
+        "immigra": {
+          "Democratic": 78355,
+          "Republican": 1947,
+          "total": 80302
+        },
+        "rights": {
+          "Democratic": 305482,
+          "Republican": 2238,
+          "total": 307720
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 62348,
+          "Republican": 0,
+          "total": 62348
+        },
+        "capitol": {
+          "Democratic": 217424,
+          "Republican": 16149,
+          "total": 233573
+        },
+        "climate": {
+          "Democratic": 680551,
+          "Republican": 166,
+          "total": 680717
+        },
+        "covid": {
+          "Democratic": 2159549,
+          "Republican": 17633,
+          "total": 2177182
+        },
+        "gun": {
+          "Democratic": 55555,
+          "Republican": 74799,
+          "total": 130354
+        },
+        "immigra": {
+          "Democratic": 78355,
+          "Republican": 1947,
+          "total": 80302
+        },
+        "rights": {
+          "Democratic": 305482,
+          "Republican": 2238,
+          "total": 307720
+        }
+      }
     },
     {
-        "state": "WI",
-        "Democratic": 3218005,
-        "Republican": 441541,
-        "total": 3659546
+      "state": "WI",
+      "Democratic": 2424141,
+      "Republican": 401696,
+      "total": 2825837,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 2839,
+          "Republican": 25755,
+          "total": 28594
+        },
+        "capitol": {
+          "Democratic": 359881,
+          "Republican": 43809,
+          "total": 403690
+        },
+        "climate": {
+          "Democratic": 8657,
+          "Republican": 66618,
+          "total": 75275
+        },
+        "covid": {
+          "Democratic": 1533609,
+          "Republican": 259013,
+          "total": 1792622
+        },
+        "gun": {
+          "Democratic": 89484,
+          "Republican": 1461,
+          "total": 90945
+        },
+        "immigra": {
+          "Democratic": 77250,
+          "Republican": 4009,
+          "total": 81259
+        },
+        "rights": {
+          "Democratic": 352421,
+          "Republican": 1031,
+          "total": 353452
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 2839,
+          "Republican": 25755,
+          "total": 28594
+        },
+        "capitol": {
+          "Democratic": 359881,
+          "Republican": 43809,
+          "total": 403690
+        },
+        "climate": {
+          "Democratic": 8657,
+          "Republican": 66618,
+          "total": 75275
+        },
+        "covid": {
+          "Democratic": 1533609,
+          "Republican": 259013,
+          "total": 1792622
+        },
+        "gun": {
+          "Democratic": 89484,
+          "Republican": 1461,
+          "total": 90945
+        },
+        "immigra": {
+          "Democratic": 77250,
+          "Republican": 4009,
+          "total": 81259
+        },
+        "rights": {
+          "Democratic": 352421,
+          "Republican": 1031,
+          "total": 353452
+        }
+      }
     },
     {
-        "state": "WV",
-        "Democratic": 783510,
-        "Republican": 514123,
-        "total": 1297633
+      "state": "WV",
+      "Democratic": 512740,
+      "Republican": 506881,
+      "total": 1019621,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 4842,
+          "Republican": 1528,
+          "total": 6370
+        },
+        "capitol": {
+          "Democratic": 178822,
+          "Republican": 410,
+          "total": 179232
+        },
+        "climate": {
+          "Democratic": 10477,
+          "Republican": 865,
+          "total": 11342
+        },
+        "covid": {
+          "Democratic": 305121,
+          "Republican": 448477,
+          "total": 753598
+        },
+        "gun": {
+          "Democratic": 10923,
+          "Republican": 19118,
+          "total": 30041
+        },
+        "immigra": {
+          "Democratic": 306,
+          "Republican": 12610,
+          "total": 12916
+        },
+        "rights": {
+          "Democratic": 2249,
+          "Republican": 23873,
+          "total": 26122
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 4842,
+          "Republican": 1528,
+          "total": 6370
+        },
+        "capitol": {
+          "Democratic": 178822,
+          "Republican": 410,
+          "total": 179232
+        },
+        "climate": {
+          "Democratic": 10477,
+          "Republican": 865,
+          "total": 11342
+        },
+        "covid": {
+          "Democratic": 305121,
+          "Republican": 448477,
+          "total": 753598
+        },
+        "gun": {
+          "Democratic": 10923,
+          "Republican": 19118,
+          "total": 30041
+        },
+        "immigra": {
+          "Democratic": 306,
+          "Republican": 12610,
+          "total": 12916
+        },
+        "rights": {
+          "Democratic": 2249,
+          "Republican": 23873,
+          "total": 26122
+        }
+      }
     },
     {
-        "state": "WY",
-        "Democratic": 8710,
-        "Republican": 443344,
-        "total": 452054
+      "state": "WY",
+      "Democratic": 5052,
+      "Republican": 445539,
+      "total": 450591,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 39,
+          "Republican": 136,
+          "total": 175
+        },
+        "capitol": {
+          "Democratic": 4,
+          "Republican": 3657,
+          "total": 3661
+        },
+        "climate": {
+          "Democratic": 3112,
+          "Republican": 2062,
+          "total": 5174
+        },
+        "covid": {
+          "Democratic": 1173,
+          "Republican": 426077,
+          "total": 427250
+        },
+        "gun": {
+          "Democratic": 717,
+          "Republican": 11413,
+          "total": 12130
+        },
+        "immigra": {
+          "Democratic": 0,
+          "Republican": 143,
+          "total": 143
+        },
+        "rights": {
+          "Democratic": 7,
+          "Republican": 2051,
+          "total": 2058
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 39,
+          "Republican": 136,
+          "total": 175
+        },
+        "capitol": {
+          "Democratic": 4,
+          "Republican": 3657,
+          "total": 3661
+        },
+        "climate": {
+          "Democratic": 3112,
+          "Republican": 2062,
+          "total": 5174
+        },
+        "covid": {
+          "Democratic": 1173,
+          "Republican": 426077,
+          "total": 427250
+        },
+        "gun": {
+          "Democratic": 717,
+          "Republican": 11413,
+          "total": 12130
+        },
+        "immigra": {
+          "Democratic": 0,
+          "Republican": 143,
+          "total": 143
+        },
+        "rights": {
+          "Democratic": 7,
+          "Republican": 2051,
+          "total": 2058
+        }
+      }
     }
-]
+  ]

--- a/civicwatch_backend/static/data/defaultChoroplethLegislators.json
+++ b/civicwatch_backend/static/data/defaultChoroplethLegislators.json
@@ -1,302 +1,4002 @@
 [
     {
-        "state": "AK",
-        "Democratic": 9,
-        "Republican": 6,
-        "total": 15
+      "state": "SC",
+      "Democratic": 26,
+      "Republican": 42,
+      "total": 68,
+      "topic_breakdown": {
+        "gun": {
+          "Democratic": 16,
+          "Republican": 19,
+          "total": 35
+        },
+        "covid": {
+          "Democratic": 26,
+          "Republican": 39,
+          "total": 65
+        },
+        "rights": {
+          "Democratic": 17,
+          "Republican": 19,
+          "total": 36
+        },
+        "capitol": {
+          "Democratic": 8,
+          "Republican": 4,
+          "total": 12
+        },
+        "immigra": {
+          "Democratic": 5,
+          "Republican": 8,
+          "total": 13
+        },
+        "abortion": {
+          "Democratic": 12,
+          "Republican": 9,
+          "total": 21
+        },
+        "climate": {
+          "Democratic": 8,
+          "Republican": 7,
+          "total": 15
+        }
+      },
+      "legislator_breakdown": {
+        "gun": {
+          "Democratic": 16,
+          "Republican": 19,
+          "total": 35
+        },
+        "covid": {
+          "Democratic": 26,
+          "Republican": 39,
+          "total": 65
+        },
+        "rights": {
+          "Democratic": 17,
+          "Republican": 19,
+          "total": 36
+        },
+        "capitol": {
+          "Democratic": 8,
+          "Republican": 4,
+          "total": 12
+        },
+        "immigra": {
+          "Democratic": 5,
+          "Republican": 8,
+          "total": 13
+        },
+        "abortion": {
+          "Democratic": 12,
+          "Republican": 9,
+          "total": 21
+        },
+        "climate": {
+          "Democratic": 8,
+          "Republican": 7,
+          "total": 15
+        }
+      }
     },
     {
-        "state": "AL",
-        "Democratic": 8,
-        "Republican": 30,
-        "total": 38
+      "state": "FL",
+      "Democratic": 51,
+      "Republican": 65,
+      "total": 116,
+      "topic_breakdown": {
+        "rights": {
+          "Democratic": 43,
+          "Republican": 45,
+          "total": 88
+        },
+        "covid": {
+          "Democratic": 51,
+          "Republican": 64,
+          "total": 115
+        },
+        "gun": {
+          "Democratic": 38,
+          "Republican": 21,
+          "total": 59
+        },
+        "climate": {
+          "Democratic": 27,
+          "Republican": 14,
+          "total": 41
+        },
+        "capitol": {
+          "Democratic": 27,
+          "Republican": 18,
+          "total": 45
+        },
+        "abortion": {
+          "Democratic": 27,
+          "Republican": 14,
+          "total": 41
+        },
+        "immigra": {
+          "Democratic": 20,
+          "Republican": 22,
+          "total": 42
+        }
+      },
+      "legislator_breakdown": {
+        "rights": {
+          "Democratic": 43,
+          "Republican": 45,
+          "total": 88
+        },
+        "covid": {
+          "Democratic": 51,
+          "Republican": 64,
+          "total": 115
+        },
+        "gun": {
+          "Democratic": 38,
+          "Republican": 21,
+          "total": 59
+        },
+        "climate": {
+          "Democratic": 27,
+          "Republican": 14,
+          "total": 41
+        },
+        "capitol": {
+          "Democratic": 27,
+          "Republican": 18,
+          "total": 45
+        },
+        "abortion": {
+          "Democratic": 27,
+          "Republican": 14,
+          "total": 41
+        },
+        "immigra": {
+          "Democratic": 20,
+          "Republican": 22,
+          "total": 42
+        }
+      }
     },
     {
-        "state": "AR",
-        "Democratic": 14,
-        "Republican": 36,
-        "total": 50
+      "state": "PA",
+      "Democratic": 66,
+      "Republican": 36,
+      "total": 102,
+      "topic_breakdown": {
+        "gun": {
+          "Democratic": 46,
+          "Republican": 20,
+          "total": 66
+        },
+        "rights": {
+          "Democratic": 48,
+          "Republican": 28,
+          "total": 76
+        },
+        "abortion": {
+          "Democratic": 25,
+          "Republican": 7,
+          "total": 32
+        },
+        "covid": {
+          "Democratic": 66,
+          "Republican": 36,
+          "total": 102
+        },
+        "capitol": {
+          "Democratic": 34,
+          "Republican": 14,
+          "total": 48
+        },
+        "immigra": {
+          "Democratic": 23,
+          "Republican": 6,
+          "total": 29
+        },
+        "climate": {
+          "Democratic": 36,
+          "Republican": 12,
+          "total": 48
+        }
+      },
+      "legislator_breakdown": {
+        "gun": {
+          "Democratic": 46,
+          "Republican": 20,
+          "total": 66
+        },
+        "rights": {
+          "Democratic": 48,
+          "Republican": 28,
+          "total": 76
+        },
+        "abortion": {
+          "Democratic": 25,
+          "Republican": 7,
+          "total": 32
+        },
+        "covid": {
+          "Democratic": 66,
+          "Republican": 36,
+          "total": 102
+        },
+        "capitol": {
+          "Democratic": 34,
+          "Republican": 14,
+          "total": 48
+        },
+        "immigra": {
+          "Democratic": 23,
+          "Republican": 6,
+          "total": 29
+        },
+        "climate": {
+          "Democratic": 36,
+          "Republican": 12,
+          "total": 48
+        }
+      }
     },
     {
-        "state": "AZ",
-        "Democratic": 36,
-        "Republican": 30,
-        "total": 66
+      "state": "IN",
+      "Democratic": 20,
+      "Republican": 36,
+      "total": 56,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 20,
+          "Republican": 35,
+          "total": 55
+        },
+        "climate": {
+          "Democratic": 9,
+          "Republican": 9,
+          "total": 18
+        },
+        "rights": {
+          "Democratic": 15,
+          "Republican": 14,
+          "total": 29
+        },
+        "gun": {
+          "Democratic": 9,
+          "Republican": 13,
+          "total": 22
+        },
+        "capitol": {
+          "Democratic": 1,
+          "Republican": 6,
+          "total": 7
+        },
+        "abortion": {
+          "Democratic": 3,
+          "Republican": 10,
+          "total": 13
+        },
+        "immigra": {
+          "Democratic": 2,
+          "Republican": 9,
+          "total": 11
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 20,
+          "Republican": 35,
+          "total": 55
+        },
+        "climate": {
+          "Democratic": 9,
+          "Republican": 9,
+          "total": 18
+        },
+        "rights": {
+          "Democratic": 15,
+          "Republican": 14,
+          "total": 29
+        },
+        "gun": {
+          "Democratic": 9,
+          "Republican": 13,
+          "total": 22
+        },
+        "capitol": {
+          "Democratic": 1,
+          "Republican": 6,
+          "total": 7
+        },
+        "abortion": {
+          "Democratic": 3,
+          "Republican": 10,
+          "total": 13
+        },
+        "immigra": {
+          "Democratic": 2,
+          "Republican": 9,
+          "total": 11
+        }
+      }
     },
     {
-        "state": "CA",
-        "Democratic": 69,
-        "Republican": 24,
-        "total": 93
+      "state": "MA",
+      "Democratic": 109,
+      "Republican": 19,
+      "total": 128,
+      "topic_breakdown": {
+        "gun": {
+          "Democratic": 57,
+          "Republican": 2,
+          "total": 59
+        },
+        "covid": {
+          "Democratic": 108,
+          "Republican": 19,
+          "total": 127
+        },
+        "immigra": {
+          "Democratic": 61,
+          "Republican": 4,
+          "total": 65
+        },
+        "climate": {
+          "Democratic": 82,
+          "Republican": 10,
+          "total": 92
+        },
+        "rights": {
+          "Democratic": 82,
+          "Republican": 10,
+          "total": 92
+        },
+        "abortion": {
+          "Democratic": 44,
+          "Republican": 1,
+          "total": 45
+        },
+        "capitol": {
+          "Democratic": 19,
+          "Republican": 2,
+          "total": 21
+        }
+      },
+      "legislator_breakdown": {
+        "gun": {
+          "Democratic": 57,
+          "Republican": 2,
+          "total": 59
+        },
+        "covid": {
+          "Democratic": 108,
+          "Republican": 19,
+          "total": 127
+        },
+        "immigra": {
+          "Democratic": 61,
+          "Republican": 4,
+          "total": 65
+        },
+        "climate": {
+          "Democratic": 82,
+          "Republican": 10,
+          "total": 92
+        },
+        "rights": {
+          "Democratic": 82,
+          "Republican": 10,
+          "total": 92
+        },
+        "abortion": {
+          "Democratic": 44,
+          "Republican": 1,
+          "total": 45
+        },
+        "capitol": {
+          "Democratic": 19,
+          "Republican": 2,
+          "total": 21
+        }
+      }
     },
     {
-        "state": "CO",
-        "Democratic": 46,
-        "Republican": 17,
-        "total": 63
+      "state": "MI",
+      "Democratic": 36,
+      "Republican": 21,
+      "total": 57,
+      "topic_breakdown": {
+        "immigra": {
+          "Democratic": 13,
+          "Republican": 3,
+          "total": 16
+        },
+        "gun": {
+          "Democratic": 25,
+          "Republican": 6,
+          "total": 31
+        },
+        "rights": {
+          "Democratic": 29,
+          "Republican": 13,
+          "total": 42
+        },
+        "covid": {
+          "Democratic": 35,
+          "Republican": 20,
+          "total": 55
+        },
+        "climate": {
+          "Democratic": 17,
+          "Republican": 4,
+          "total": 21
+        },
+        "capitol": {
+          "Democratic": 24,
+          "Republican": 3,
+          "total": 27
+        },
+        "abortion": {
+          "Democratic": 15,
+          "Republican": 3,
+          "total": 18
+        }
+      },
+      "legislator_breakdown": {
+        "immigra": {
+          "Democratic": 13,
+          "Republican": 3,
+          "total": 16
+        },
+        "gun": {
+          "Democratic": 25,
+          "Republican": 6,
+          "total": 31
+        },
+        "rights": {
+          "Democratic": 29,
+          "Republican": 13,
+          "total": 42
+        },
+        "covid": {
+          "Democratic": 35,
+          "Republican": 20,
+          "total": 55
+        },
+        "climate": {
+          "Democratic": 17,
+          "Republican": 4,
+          "total": 21
+        },
+        "capitol": {
+          "Democratic": 24,
+          "Republican": 3,
+          "total": 27
+        },
+        "abortion": {
+          "Democratic": 15,
+          "Republican": 3,
+          "total": 18
+        }
+      }
     },
     {
-        "state": "CT",
-        "Democratic": 36,
-        "Republican": 20,
-        "total": 56
+      "state": "TX",
+      "Democratic": 53,
+      "Republican": 81,
+      "total": 134,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 52,
+          "Republican": 77,
+          "total": 129
+        },
+        "rights": {
+          "Democratic": 51,
+          "Republican": 63,
+          "total": 114
+        },
+        "immigra": {
+          "Democratic": 36,
+          "Republican": 29,
+          "total": 65
+        },
+        "gun": {
+          "Democratic": 43,
+          "Republican": 44,
+          "total": 87
+        },
+        "capitol": {
+          "Democratic": 28,
+          "Republican": 29,
+          "total": 57
+        },
+        "abortion": {
+          "Democratic": 33,
+          "Republican": 45,
+          "total": 78
+        },
+        "climate": {
+          "Democratic": 30,
+          "Republican": 24,
+          "total": 54
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 52,
+          "Republican": 77,
+          "total": 129
+        },
+        "rights": {
+          "Democratic": 51,
+          "Republican": 63,
+          "total": 114
+        },
+        "immigra": {
+          "Democratic": 36,
+          "Republican": 29,
+          "total": 65
+        },
+        "gun": {
+          "Democratic": 43,
+          "Republican": 44,
+          "total": 87
+        },
+        "capitol": {
+          "Democratic": 28,
+          "Republican": 29,
+          "total": 57
+        },
+        "abortion": {
+          "Democratic": 33,
+          "Republican": 45,
+          "total": 78
+        },
+        "climate": {
+          "Democratic": 30,
+          "Republican": 24,
+          "total": 54
+        }
+      }
     },
     {
-        "state": "DE",
-        "Democratic": 9,
-        "Republican": 2,
-        "total": 11
+      "state": "OH",
+      "Democratic": 27,
+      "Republican": 44,
+      "total": 71,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 27,
+          "Republican": 40,
+          "total": 67
+        },
+        "immigra": {
+          "Democratic": 8,
+          "Republican": 5,
+          "total": 13
+        },
+        "abortion": {
+          "Democratic": 13,
+          "Republican": 11,
+          "total": 24
+        },
+        "rights": {
+          "Democratic": 22,
+          "Republican": 27,
+          "total": 49
+        },
+        "gun": {
+          "Democratic": 19,
+          "Republican": 17,
+          "total": 36
+        },
+        "climate": {
+          "Democratic": 12,
+          "Republican": 6,
+          "total": 18
+        },
+        "capitol": {
+          "Democratic": 10,
+          "Republican": 9,
+          "total": 19
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 27,
+          "Republican": 40,
+          "total": 67
+        },
+        "immigra": {
+          "Democratic": 8,
+          "Republican": 5,
+          "total": 13
+        },
+        "abortion": {
+          "Democratic": 13,
+          "Republican": 11,
+          "total": 24
+        },
+        "rights": {
+          "Democratic": 22,
+          "Republican": 27,
+          "total": 49
+        },
+        "gun": {
+          "Democratic": 19,
+          "Republican": 17,
+          "total": 36
+        },
+        "climate": {
+          "Democratic": 12,
+          "Republican": 6,
+          "total": 18
+        },
+        "capitol": {
+          "Democratic": 10,
+          "Republican": 9,
+          "total": 19
+        }
+      }
     },
     {
-        "state": "FL",
-        "Democratic": 51,
-        "Republican": 65,
-        "total": 116
+      "state": "KY",
+      "Democratic": 16,
+      "Republican": 42,
+      "total": 58,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 16,
+          "Republican": 40,
+          "total": 56
+        },
+        "rights": {
+          "Democratic": 11,
+          "Republican": 19,
+          "total": 30
+        },
+        "capitol": {
+          "Democratic": 6,
+          "Republican": 21,
+          "total": 27
+        },
+        "immigra": {
+          "Democratic": 6,
+          "Republican": 8,
+          "total": 14
+        },
+        "abortion": {
+          "Democratic": 4,
+          "Republican": 14,
+          "total": 18
+        },
+        "gun": {
+          "Democratic": 8,
+          "Republican": 11,
+          "total": 19
+        },
+        "climate": {
+          "Democratic": 5,
+          "Republican": 4,
+          "total": 9
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 16,
+          "Republican": 40,
+          "total": 56
+        },
+        "rights": {
+          "Democratic": 11,
+          "Republican": 19,
+          "total": 30
+        },
+        "capitol": {
+          "Democratic": 6,
+          "Republican": 21,
+          "total": 27
+        },
+        "immigra": {
+          "Democratic": 6,
+          "Republican": 8,
+          "total": 14
+        },
+        "abortion": {
+          "Democratic": 4,
+          "Republican": 14,
+          "total": 18
+        },
+        "gun": {
+          "Democratic": 8,
+          "Republican": 11,
+          "total": 19
+        },
+        "climate": {
+          "Democratic": 5,
+          "Republican": 4,
+          "total": 9
+        }
+      }
     },
     {
-        "state": "GA",
-        "Democratic": 53,
-        "Republican": 46,
-        "total": 99
+      "state": "VA",
+      "Democratic": 51,
+      "Republican": 24,
+      "total": 75,
+      "topic_breakdown": {
+        "gun": {
+          "Democratic": 47,
+          "Republican": 13,
+          "total": 60
+        },
+        "rights": {
+          "Democratic": 46,
+          "Republican": 18,
+          "total": 64
+        },
+        "covid": {
+          "Democratic": 49,
+          "Republican": 21,
+          "total": 70
+        },
+        "abortion": {
+          "Democratic": 28,
+          "Republican": 6,
+          "total": 34
+        },
+        "climate": {
+          "Democratic": 37,
+          "Republican": 6,
+          "total": 43
+        },
+        "capitol": {
+          "Democratic": 30,
+          "Republican": 16,
+          "total": 46
+        },
+        "immigra": {
+          "Democratic": 26,
+          "Republican": 7,
+          "total": 33
+        }
+      },
+      "legislator_breakdown": {
+        "gun": {
+          "Democratic": 47,
+          "Republican": 13,
+          "total": 60
+        },
+        "rights": {
+          "Democratic": 46,
+          "Republican": 18,
+          "total": 64
+        },
+        "covid": {
+          "Democratic": 49,
+          "Republican": 21,
+          "total": 70
+        },
+        "abortion": {
+          "Democratic": 28,
+          "Republican": 6,
+          "total": 34
+        },
+        "climate": {
+          "Democratic": 37,
+          "Republican": 6,
+          "total": 43
+        },
+        "capitol": {
+          "Democratic": 30,
+          "Republican": 16,
+          "total": 46
+        },
+        "immigra": {
+          "Democratic": 26,
+          "Republican": 7,
+          "total": 33
+        }
+      }
     },
     {
-        "state": "HI",
-        "Democratic": 16,
-        "Republican": 3,
-        "total": 19
+      "state": "CA",
+      "Democratic": 69,
+      "Republican": 24,
+      "total": 93,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 68,
+          "Republican": 24,
+          "total": 92
+        },
+        "immigra": {
+          "Democratic": 53,
+          "Republican": 10,
+          "total": 63
+        },
+        "climate": {
+          "Democratic": 61,
+          "Republican": 16,
+          "total": 77
+        },
+        "rights": {
+          "Democratic": 62,
+          "Republican": 18,
+          "total": 80
+        },
+        "gun": {
+          "Democratic": 45,
+          "Republican": 10,
+          "total": 55
+        },
+        "capitol": {
+          "Democratic": 26,
+          "Republican": 8,
+          "total": 34
+        },
+        "abortion": {
+          "Democratic": 30,
+          "Republican": 0,
+          "total": 30
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 68,
+          "Republican": 24,
+          "total": 92
+        },
+        "immigra": {
+          "Democratic": 53,
+          "Republican": 10,
+          "total": 63
+        },
+        "climate": {
+          "Democratic": 61,
+          "Republican": 16,
+          "total": 77
+        },
+        "rights": {
+          "Democratic": 62,
+          "Republican": 18,
+          "total": 80
+        },
+        "gun": {
+          "Democratic": 45,
+          "Republican": 10,
+          "total": 55
+        },
+        "capitol": {
+          "Democratic": 26,
+          "Republican": 8,
+          "total": 34
+        },
+        "abortion": {
+          "Democratic": 30,
+          "Republican": 0,
+          "total": 30
+        }
+      }
     },
     {
-        "state": "IA",
-        "Democratic": 34,
-        "Republican": 18,
-        "total": 52
+      "state": "NE",
+      "Democratic": 11,
+      "Republican": 4,
+      "total": 15,
+      "topic_breakdown": {
+        "rights": {
+          "Democratic": 10,
+          "Republican": 0,
+          "total": 10
+        },
+        "gun": {
+          "Democratic": 5,
+          "Republican": 0,
+          "total": 5
+        },
+        "abortion": {
+          "Democratic": 1,
+          "Republican": 0,
+          "total": 1
+        },
+        "capitol": {
+          "Democratic": 5,
+          "Republican": 0,
+          "total": 5
+        },
+        "covid": {
+          "Democratic": 11,
+          "Republican": 4,
+          "total": 15
+        },
+        "immigra": {
+          "Democratic": 4,
+          "Republican": 0,
+          "total": 4
+        },
+        "climate": {
+          "Democratic": 4,
+          "Republican": 0,
+          "total": 4
+        }
+      },
+      "legislator_breakdown": {
+        "rights": {
+          "Democratic": 10,
+          "Republican": 0,
+          "total": 10
+        },
+        "gun": {
+          "Democratic": 5,
+          "Republican": 0,
+          "total": 5
+        },
+        "abortion": {
+          "Democratic": 1,
+          "Republican": 0,
+          "total": 1
+        },
+        "capitol": {
+          "Democratic": 5,
+          "Republican": 0,
+          "total": 5
+        },
+        "covid": {
+          "Democratic": 11,
+          "Republican": 4,
+          "total": 15
+        },
+        "immigra": {
+          "Democratic": 4,
+          "Republican": 0,
+          "total": 4
+        },
+        "climate": {
+          "Democratic": 4,
+          "Republican": 0,
+          "total": 4
+        }
+      }
     },
     {
-        "state": "ID",
-        "Democratic": 9,
-        "Republican": 11,
-        "total": 20
+      "state": "UT",
+      "Democratic": 15,
+      "Republican": 32,
+      "total": 47,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 15,
+          "Republican": 28,
+          "total": 43
+        },
+        "rights": {
+          "Democratic": 12,
+          "Republican": 15,
+          "total": 27
+        },
+        "abortion": {
+          "Democratic": 8,
+          "Republican": 4,
+          "total": 12
+        },
+        "gun": {
+          "Democratic": 11,
+          "Republican": 8,
+          "total": 19
+        },
+        "immigra": {
+          "Democratic": 8,
+          "Republican": 7,
+          "total": 15
+        },
+        "climate": {
+          "Democratic": 10,
+          "Republican": 4,
+          "total": 14
+        },
+        "capitol": {
+          "Democratic": 8,
+          "Republican": 9,
+          "total": 17
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 15,
+          "Republican": 28,
+          "total": 43
+        },
+        "rights": {
+          "Democratic": 12,
+          "Republican": 15,
+          "total": 27
+        },
+        "abortion": {
+          "Democratic": 8,
+          "Republican": 4,
+          "total": 12
+        },
+        "gun": {
+          "Democratic": 11,
+          "Republican": 8,
+          "total": 19
+        },
+        "immigra": {
+          "Democratic": 8,
+          "Republican": 7,
+          "total": 15
+        },
+        "climate": {
+          "Democratic": 10,
+          "Republican": 4,
+          "total": 14
+        },
+        "capitol": {
+          "Democratic": 8,
+          "Republican": 9,
+          "total": 17
+        }
+      }
     },
     {
-        "state": "IL",
-        "Democratic": 44,
-        "Republican": 23,
-        "total": 67
+      "state": "RI",
+      "Democratic": 45,
+      "Republican": 8,
+      "total": 53,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 42,
+          "Republican": 8,
+          "total": 50
+        },
+        "immigra": {
+          "Democratic": 14,
+          "Republican": 2,
+          "total": 16
+        },
+        "gun": {
+          "Democratic": 29,
+          "Republican": 7,
+          "total": 36
+        },
+        "climate": {
+          "Democratic": 27,
+          "Republican": 6,
+          "total": 33
+        },
+        "rights": {
+          "Democratic": 27,
+          "Republican": 5,
+          "total": 32
+        },
+        "capitol": {
+          "Democratic": 16,
+          "Republican": 6,
+          "total": 22
+        },
+        "abortion": {
+          "Democratic": 13,
+          "Republican": 3,
+          "total": 16
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 42,
+          "Republican": 8,
+          "total": 50
+        },
+        "immigra": {
+          "Democratic": 14,
+          "Republican": 2,
+          "total": 16
+        },
+        "gun": {
+          "Democratic": 29,
+          "Republican": 7,
+          "total": 36
+        },
+        "climate": {
+          "Democratic": 27,
+          "Republican": 6,
+          "total": 33
+        },
+        "rights": {
+          "Democratic": 27,
+          "Republican": 5,
+          "total": 32
+        },
+        "capitol": {
+          "Democratic": 16,
+          "Republican": 6,
+          "total": 22
+        },
+        "abortion": {
+          "Democratic": 13,
+          "Republican": 3,
+          "total": 16
+        }
+      }
     },
     {
-        "state": "IN",
-        "Democratic": 21,
-        "Republican": 36,
-        "total": 57
+      "state": "MO",
+      "Democratic": 37,
+      "Republican": 65,
+      "total": 102,
+      "topic_breakdown": {
+        "rights": {
+          "Democratic": 30,
+          "Republican": 41,
+          "total": 71
+        },
+        "covid": {
+          "Democratic": 37,
+          "Republican": 58,
+          "total": 95
+        },
+        "abortion": {
+          "Democratic": 23,
+          "Republican": 30,
+          "total": 53
+        },
+        "capitol": {
+          "Democratic": 20,
+          "Republican": 17,
+          "total": 37
+        },
+        "gun": {
+          "Democratic": 32,
+          "Republican": 35,
+          "total": 67
+        },
+        "climate": {
+          "Democratic": 16,
+          "Republican": 10,
+          "total": 26
+        },
+        "immigra": {
+          "Democratic": 17,
+          "Republican": 11,
+          "total": 28
+        }
+      },
+      "legislator_breakdown": {
+        "rights": {
+          "Democratic": 30,
+          "Republican": 41,
+          "total": 71
+        },
+        "covid": {
+          "Democratic": 37,
+          "Republican": 58,
+          "total": 95
+        },
+        "abortion": {
+          "Democratic": 23,
+          "Republican": 30,
+          "total": 53
+        },
+        "capitol": {
+          "Democratic": 20,
+          "Republican": 17,
+          "total": 37
+        },
+        "gun": {
+          "Democratic": 32,
+          "Republican": 35,
+          "total": 67
+        },
+        "climate": {
+          "Democratic": 16,
+          "Republican": 10,
+          "total": 26
+        },
+        "immigra": {
+          "Democratic": 17,
+          "Republican": 11,
+          "total": 28
+        }
+      }
     },
     {
-        "state": "KS",
-        "Democratic": 22,
-        "Republican": 19,
-        "total": 41
+      "state": "KS",
+      "Democratic": 22,
+      "Republican": 19,
+      "total": 41,
+      "topic_breakdown": {
+        "rights": {
+          "Democratic": 15,
+          "Republican": 12,
+          "total": 27
+        },
+        "abortion": {
+          "Democratic": 9,
+          "Republican": 10,
+          "total": 19
+        },
+        "covid": {
+          "Democratic": 22,
+          "Republican": 18,
+          "total": 40
+        },
+        "gun": {
+          "Democratic": 11,
+          "Republican": 6,
+          "total": 17
+        },
+        "climate": {
+          "Democratic": 7,
+          "Republican": 4,
+          "total": 11
+        },
+        "immigra": {
+          "Democratic": 5,
+          "Republican": 2,
+          "total": 7
+        },
+        "capitol": {
+          "Democratic": 8,
+          "Republican": 1,
+          "total": 9
+        }
+      },
+      "legislator_breakdown": {
+        "rights": {
+          "Democratic": 15,
+          "Republican": 12,
+          "total": 27
+        },
+        "abortion": {
+          "Democratic": 9,
+          "Republican": 10,
+          "total": 19
+        },
+        "covid": {
+          "Democratic": 22,
+          "Republican": 18,
+          "total": 40
+        },
+        "gun": {
+          "Democratic": 11,
+          "Republican": 6,
+          "total": 17
+        },
+        "climate": {
+          "Democratic": 7,
+          "Republican": 4,
+          "total": 11
+        },
+        "immigra": {
+          "Democratic": 5,
+          "Republican": 2,
+          "total": 7
+        },
+        "capitol": {
+          "Democratic": 8,
+          "Republican": 1,
+          "total": 9
+        }
+      }
     },
     {
-        "state": "KY",
-        "Democratic": 16,
-        "Republican": 42,
-        "total": 58
+      "state": "NJ",
+      "Democratic": 36,
+      "Republican": 22,
+      "total": 58,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 36,
+          "Republican": 22,
+          "total": 58
+        },
+        "climate": {
+          "Democratic": 18,
+          "Republican": 3,
+          "total": 21
+        },
+        "rights": {
+          "Democratic": 25,
+          "Republican": 12,
+          "total": 37
+        },
+        "abortion": {
+          "Democratic": 4,
+          "Republican": 1,
+          "total": 5
+        },
+        "gun": {
+          "Democratic": 16,
+          "Republican": 7,
+          "total": 23
+        },
+        "capitol": {
+          "Democratic": 7,
+          "Republican": 1,
+          "total": 8
+        },
+        "immigra": {
+          "Democratic": 16,
+          "Republican": 6,
+          "total": 22
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 36,
+          "Republican": 22,
+          "total": 58
+        },
+        "climate": {
+          "Democratic": 18,
+          "Republican": 3,
+          "total": 21
+        },
+        "rights": {
+          "Democratic": 25,
+          "Republican": 12,
+          "total": 37
+        },
+        "abortion": {
+          "Democratic": 4,
+          "Republican": 1,
+          "total": 5
+        },
+        "gun": {
+          "Democratic": 16,
+          "Republican": 7,
+          "total": 23
+        },
+        "capitol": {
+          "Democratic": 7,
+          "Republican": 1,
+          "total": 8
+        },
+        "immigra": {
+          "Democratic": 16,
+          "Republican": 6,
+          "total": 22
+        }
+      }
     },
     {
-        "state": "LA",
-        "Democratic": 12,
-        "Republican": 24,
-        "total": 36
+      "state": "HI",
+      "Democratic": 15,
+      "Republican": 3,
+      "total": 18,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 14,
+          "Republican": 3,
+          "total": 17
+        },
+        "climate": {
+          "Democratic": 9,
+          "Republican": 0,
+          "total": 9
+        },
+        "rights": {
+          "Democratic": 6,
+          "Republican": 1,
+          "total": 7
+        },
+        "capitol": {
+          "Democratic": 6,
+          "Republican": 0,
+          "total": 6
+        },
+        "abortion": {
+          "Democratic": 2,
+          "Republican": 1,
+          "total": 3
+        },
+        "gun": {
+          "Democratic": 10,
+          "Republican": 1,
+          "total": 11
+        },
+        "immigra": {
+          "Democratic": 2,
+          "Republican": 0,
+          "total": 2
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 14,
+          "Republican": 3,
+          "total": 17
+        },
+        "climate": {
+          "Democratic": 9,
+          "Republican": 0,
+          "total": 9
+        },
+        "rights": {
+          "Democratic": 6,
+          "Republican": 1,
+          "total": 7
+        },
+        "capitol": {
+          "Democratic": 6,
+          "Republican": 0,
+          "total": 6
+        },
+        "abortion": {
+          "Democratic": 2,
+          "Republican": 1,
+          "total": 3
+        },
+        "gun": {
+          "Democratic": 10,
+          "Republican": 1,
+          "total": 11
+        },
+        "immigra": {
+          "Democratic": 2,
+          "Republican": 0,
+          "total": 2
+        }
+      }
     },
     {
-        "state": "MA",
-        "Democratic": 109,
-        "Republican": 19,
-        "total": 128
+      "state": "LA",
+      "Democratic": 12,
+      "Republican": 24,
+      "total": 36,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 12,
+          "Republican": 24,
+          "total": 36
+        },
+        "rights": {
+          "Democratic": 7,
+          "Republican": 11,
+          "total": 18
+        },
+        "climate": {
+          "Democratic": 5,
+          "Republican": 8,
+          "total": 13
+        },
+        "gun": {
+          "Democratic": 7,
+          "Republican": 9,
+          "total": 16
+        },
+        "abortion": {
+          "Democratic": 4,
+          "Republican": 6,
+          "total": 10
+        },
+        "capitol": {
+          "Democratic": 5,
+          "Republican": 1,
+          "total": 6
+        },
+        "immigra": {
+          "Democratic": 2,
+          "Republican": 3,
+          "total": 5
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 12,
+          "Republican": 24,
+          "total": 36
+        },
+        "rights": {
+          "Democratic": 7,
+          "Republican": 11,
+          "total": 18
+        },
+        "climate": {
+          "Democratic": 5,
+          "Republican": 8,
+          "total": 13
+        },
+        "gun": {
+          "Democratic": 7,
+          "Republican": 9,
+          "total": 16
+        },
+        "abortion": {
+          "Democratic": 4,
+          "Republican": 6,
+          "total": 10
+        },
+        "capitol": {
+          "Democratic": 5,
+          "Republican": 1,
+          "total": 6
+        },
+        "immigra": {
+          "Democratic": 2,
+          "Republican": 3,
+          "total": 5
+        }
+      }
     },
     {
-        "state": "MD",
-        "Democratic": 72,
-        "Republican": 17,
-        "total": 89
+      "state": "MN",
+      "Democratic": 75,
+      "Republican": 41,
+      "total": 116,
+      "topic_breakdown": {
+        "gun": {
+          "Democratic": 56,
+          "Republican": 15,
+          "total": 71
+        },
+        "covid": {
+          "Democratic": 73,
+          "Republican": 40,
+          "total": 113
+        },
+        "immigra": {
+          "Democratic": 43,
+          "Republican": 9,
+          "total": 52
+        },
+        "capitol": {
+          "Democratic": 46,
+          "Republican": 18,
+          "total": 64
+        },
+        "abortion": {
+          "Democratic": 36,
+          "Republican": 9,
+          "total": 45
+        },
+        "climate": {
+          "Democratic": 58,
+          "Republican": 7,
+          "total": 65
+        },
+        "rights": {
+          "Democratic": 62,
+          "Republican": 21,
+          "total": 83
+        }
+      },
+      "legislator_breakdown": {
+        "gun": {
+          "Democratic": 56,
+          "Republican": 15,
+          "total": 71
+        },
+        "covid": {
+          "Democratic": 73,
+          "Republican": 40,
+          "total": 113
+        },
+        "immigra": {
+          "Democratic": 43,
+          "Republican": 9,
+          "total": 52
+        },
+        "capitol": {
+          "Democratic": 46,
+          "Republican": 18,
+          "total": 64
+        },
+        "abortion": {
+          "Democratic": 36,
+          "Republican": 9,
+          "total": 45
+        },
+        "climate": {
+          "Democratic": 58,
+          "Republican": 7,
+          "total": 65
+        },
+        "rights": {
+          "Democratic": 62,
+          "Republican": 21,
+          "total": 83
+        }
+      }
     },
     {
-        "state": "ME",
-        "Democratic": 34,
-        "Republican": 5,
-        "total": 39
+      "state": "IA",
+      "Democratic": 34,
+      "Republican": 18,
+      "total": 52,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 33,
+          "Republican": 17,
+          "total": 50
+        },
+        "gun": {
+          "Democratic": 20,
+          "Republican": 10,
+          "total": 30
+        },
+        "rights": {
+          "Democratic": 27,
+          "Republican": 9,
+          "total": 36
+        },
+        "climate": {
+          "Democratic": 15,
+          "Republican": 4,
+          "total": 19
+        },
+        "abortion": {
+          "Democratic": 12,
+          "Republican": 4,
+          "total": 16
+        },
+        "immigra": {
+          "Democratic": 11,
+          "Republican": 4,
+          "total": 15
+        },
+        "capitol": {
+          "Democratic": 17,
+          "Republican": 1,
+          "total": 18
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 33,
+          "Republican": 17,
+          "total": 50
+        },
+        "gun": {
+          "Democratic": 20,
+          "Republican": 10,
+          "total": 30
+        },
+        "rights": {
+          "Democratic": 27,
+          "Republican": 9,
+          "total": 36
+        },
+        "climate": {
+          "Democratic": 15,
+          "Republican": 4,
+          "total": 19
+        },
+        "abortion": {
+          "Democratic": 12,
+          "Republican": 4,
+          "total": 16
+        },
+        "immigra": {
+          "Democratic": 11,
+          "Republican": 4,
+          "total": 15
+        },
+        "capitol": {
+          "Democratic": 17,
+          "Republican": 1,
+          "total": 18
+        }
+      }
     },
     {
-        "state": "MI",
-        "Democratic": 36,
-        "Republican": 21,
-        "total": 57
+      "state": "NH",
+      "Democratic": 78,
+      "Republican": 33,
+      "total": 111,
+      "topic_breakdown": {
+        "rights": {
+          "Democratic": 62,
+          "Republican": 19,
+          "total": 81
+        },
+        "immigra": {
+          "Democratic": 34,
+          "Republican": 13,
+          "total": 47
+        },
+        "abortion": {
+          "Democratic": 56,
+          "Republican": 16,
+          "total": 72
+        },
+        "covid": {
+          "Democratic": 77,
+          "Republican": 29,
+          "total": 106
+        },
+        "gun": {
+          "Democratic": 56,
+          "Republican": 23,
+          "total": 79
+        },
+        "capitol": {
+          "Democratic": 43,
+          "Republican": 7,
+          "total": 50
+        },
+        "climate": {
+          "Democratic": 50,
+          "Republican": 8,
+          "total": 58
+        }
+      },
+      "legislator_breakdown": {
+        "rights": {
+          "Democratic": 62,
+          "Republican": 19,
+          "total": 81
+        },
+        "immigra": {
+          "Democratic": 34,
+          "Republican": 13,
+          "total": 47
+        },
+        "abortion": {
+          "Democratic": 56,
+          "Republican": 16,
+          "total": 72
+        },
+        "covid": {
+          "Democratic": 77,
+          "Republican": 29,
+          "total": 106
+        },
+        "gun": {
+          "Democratic": 56,
+          "Republican": 23,
+          "total": 79
+        },
+        "capitol": {
+          "Democratic": 43,
+          "Republican": 7,
+          "total": 50
+        },
+        "climate": {
+          "Democratic": 50,
+          "Republican": 8,
+          "total": 58
+        }
+      }
     },
     {
-        "state": "MN",
-        "Democratic": 75,
-        "Republican": 41,
-        "total": 116
+      "state": "NY",
+      "Democratic": 103,
+      "Republican": 34,
+      "total": 137,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 103,
+          "Republican": 34,
+          "total": 137
+        },
+        "climate": {
+          "Democratic": 77,
+          "Republican": 14,
+          "total": 91
+        },
+        "gun": {
+          "Democratic": 81,
+          "Republican": 16,
+          "total": 97
+        },
+        "immigra": {
+          "Democratic": 78,
+          "Republican": 17,
+          "total": 95
+        },
+        "rights": {
+          "Democratic": 91,
+          "Republican": 23,
+          "total": 114
+        },
+        "abortion": {
+          "Democratic": 37,
+          "Republican": 2,
+          "total": 39
+        },
+        "capitol": {
+          "Democratic": 32,
+          "Republican": 10,
+          "total": 42
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 103,
+          "Republican": 34,
+          "total": 137
+        },
+        "climate": {
+          "Democratic": 77,
+          "Republican": 14,
+          "total": 91
+        },
+        "gun": {
+          "Democratic": 81,
+          "Republican": 16,
+          "total": 97
+        },
+        "immigra": {
+          "Democratic": 78,
+          "Republican": 17,
+          "total": 95
+        },
+        "rights": {
+          "Democratic": 91,
+          "Republican": 23,
+          "total": 114
+        },
+        "abortion": {
+          "Democratic": 37,
+          "Republican": 2,
+          "total": 39
+        },
+        "capitol": {
+          "Democratic": 32,
+          "Republican": 10,
+          "total": 42
+        }
+      }
     },
     {
-        "state": "MO",
-        "Democratic": 37,
-        "Republican": 66,
-        "total": 103
+      "state": "AR",
+      "Democratic": 14,
+      "Republican": 36,
+      "total": 50,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 14,
+          "Republican": 35,
+          "total": 49
+        },
+        "abortion": {
+          "Democratic": 4,
+          "Republican": 17,
+          "total": 21
+        },
+        "rights": {
+          "Democratic": 8,
+          "Republican": 18,
+          "total": 26
+        },
+        "gun": {
+          "Democratic": 11,
+          "Republican": 18,
+          "total": 29
+        },
+        "immigra": {
+          "Democratic": 7,
+          "Republican": 10,
+          "total": 17
+        },
+        "climate": {
+          "Democratic": 5,
+          "Republican": 6,
+          "total": 11
+        },
+        "capitol": {
+          "Democratic": 7,
+          "Republican": 6,
+          "total": 13
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 14,
+          "Republican": 35,
+          "total": 49
+        },
+        "abortion": {
+          "Democratic": 4,
+          "Republican": 17,
+          "total": 21
+        },
+        "rights": {
+          "Democratic": 8,
+          "Republican": 18,
+          "total": 26
+        },
+        "gun": {
+          "Democratic": 11,
+          "Republican": 18,
+          "total": 29
+        },
+        "immigra": {
+          "Democratic": 7,
+          "Republican": 10,
+          "total": 17
+        },
+        "climate": {
+          "Democratic": 5,
+          "Republican": 6,
+          "total": 11
+        },
+        "capitol": {
+          "Democratic": 7,
+          "Republican": 6,
+          "total": 13
+        }
+      }
     },
     {
-        "state": "MS",
-        "Democratic": 7,
-        "Republican": 27,
-        "total": 34
+      "state": "MT",
+      "Democratic": 15,
+      "Republican": 12,
+      "total": 27,
+      "topic_breakdown": {
+        "rights": {
+          "Democratic": 12,
+          "Republican": 6,
+          "total": 18
+        },
+        "gun": {
+          "Democratic": 9,
+          "Republican": 5,
+          "total": 14
+        },
+        "covid": {
+          "Democratic": 15,
+          "Republican": 10,
+          "total": 25
+        },
+        "capitol": {
+          "Democratic": 11,
+          "Republican": 4,
+          "total": 15
+        },
+        "abortion": {
+          "Democratic": 6,
+          "Republican": 1,
+          "total": 7
+        },
+        "climate": {
+          "Democratic": 8,
+          "Republican": 4,
+          "total": 12
+        },
+        "immigra": {
+          "Democratic": 3,
+          "Republican": 1,
+          "total": 4
+        }
+      },
+      "legislator_breakdown": {
+        "rights": {
+          "Democratic": 12,
+          "Republican": 6,
+          "total": 18
+        },
+        "gun": {
+          "Democratic": 9,
+          "Republican": 5,
+          "total": 14
+        },
+        "covid": {
+          "Democratic": 15,
+          "Republican": 10,
+          "total": 25
+        },
+        "capitol": {
+          "Democratic": 11,
+          "Republican": 4,
+          "total": 15
+        },
+        "abortion": {
+          "Democratic": 6,
+          "Republican": 1,
+          "total": 7
+        },
+        "climate": {
+          "Democratic": 8,
+          "Republican": 4,
+          "total": 12
+        },
+        "immigra": {
+          "Democratic": 3,
+          "Republican": 1,
+          "total": 4
+        }
+      }
     },
     {
-        "state": "MT",
-        "Democratic": 15,
-        "Republican": 12,
-        "total": 27
+      "state": "CO",
+      "Democratic": 46,
+      "Republican": 17,
+      "total": 63,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 46,
+          "Republican": 16,
+          "total": 62
+        },
+        "immigra": {
+          "Democratic": 28,
+          "Republican": 3,
+          "total": 31
+        },
+        "capitol": {
+          "Democratic": 35,
+          "Republican": 10,
+          "total": 45
+        },
+        "gun": {
+          "Democratic": 36,
+          "Republican": 7,
+          "total": 43
+        },
+        "abortion": {
+          "Democratic": 29,
+          "Republican": 3,
+          "total": 32
+        },
+        "rights": {
+          "Democratic": 40,
+          "Republican": 13,
+          "total": 53
+        },
+        "climate": {
+          "Democratic": 35,
+          "Republican": 6,
+          "total": 41
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 46,
+          "Republican": 16,
+          "total": 62
+        },
+        "immigra": {
+          "Democratic": 28,
+          "Republican": 3,
+          "total": 31
+        },
+        "capitol": {
+          "Democratic": 35,
+          "Republican": 10,
+          "total": 45
+        },
+        "gun": {
+          "Democratic": 36,
+          "Republican": 7,
+          "total": 43
+        },
+        "abortion": {
+          "Democratic": 29,
+          "Republican": 3,
+          "total": 32
+        },
+        "rights": {
+          "Democratic": 40,
+          "Republican": 13,
+          "total": 53
+        },
+        "climate": {
+          "Democratic": 35,
+          "Republican": 6,
+          "total": 41
+        }
+      }
     },
     {
-        "state": "NC",
-        "Democratic": 52,
-        "Republican": 37,
-        "total": 89
+      "state": "CT",
+      "Democratic": 36,
+      "Republican": 20,
+      "total": 56,
+      "topic_breakdown": {
+        "gun": {
+          "Democratic": 21,
+          "Republican": 5,
+          "total": 26
+        },
+        "covid": {
+          "Democratic": 32,
+          "Republican": 17,
+          "total": 49
+        },
+        "rights": {
+          "Democratic": 22,
+          "Republican": 8,
+          "total": 30
+        },
+        "capitol": {
+          "Democratic": 14,
+          "Republican": 8,
+          "total": 22
+        },
+        "abortion": {
+          "Democratic": 7,
+          "Republican": 0,
+          "total": 7
+        },
+        "climate": {
+          "Democratic": 20,
+          "Republican": 4,
+          "total": 24
+        },
+        "immigra": {
+          "Democratic": 12,
+          "Republican": 1,
+          "total": 13
+        }
+      },
+      "legislator_breakdown": {
+        "gun": {
+          "Democratic": 21,
+          "Republican": 5,
+          "total": 26
+        },
+        "covid": {
+          "Democratic": 32,
+          "Republican": 17,
+          "total": 49
+        },
+        "rights": {
+          "Democratic": 22,
+          "Republican": 8,
+          "total": 30
+        },
+        "capitol": {
+          "Democratic": 14,
+          "Republican": 8,
+          "total": 22
+        },
+        "abortion": {
+          "Democratic": 7,
+          "Republican": 0,
+          "total": 7
+        },
+        "climate": {
+          "Democratic": 20,
+          "Republican": 4,
+          "total": 24
+        },
+        "immigra": {
+          "Democratic": 12,
+          "Republican": 1,
+          "total": 13
+        }
+      }
     },
     {
-        "state": "ND",
-        "Democratic": 5,
-        "Republican": 11,
-        "total": 16
+      "state": "WA",
+      "Democratic": 40,
+      "Republican": 16,
+      "total": 56,
+      "topic_breakdown": {
+        "climate": {
+          "Democratic": 29,
+          "Republican": 7,
+          "total": 36
+        },
+        "gun": {
+          "Democratic": 21,
+          "Republican": 9,
+          "total": 30
+        },
+        "covid": {
+          "Democratic": 40,
+          "Republican": 15,
+          "total": 55
+        },
+        "immigra": {
+          "Democratic": 18,
+          "Republican": 3,
+          "total": 21
+        },
+        "rights": {
+          "Democratic": 28,
+          "Republican": 8,
+          "total": 36
+        },
+        "abortion": {
+          "Democratic": 13,
+          "Republican": 0,
+          "total": 13
+        },
+        "capitol": {
+          "Democratic": 12,
+          "Republican": 4,
+          "total": 16
+        }
+      },
+      "legislator_breakdown": {
+        "climate": {
+          "Democratic": 29,
+          "Republican": 7,
+          "total": 36
+        },
+        "gun": {
+          "Democratic": 21,
+          "Republican": 9,
+          "total": 30
+        },
+        "covid": {
+          "Democratic": 40,
+          "Republican": 15,
+          "total": 55
+        },
+        "immigra": {
+          "Democratic": 18,
+          "Republican": 3,
+          "total": 21
+        },
+        "rights": {
+          "Democratic": 28,
+          "Republican": 8,
+          "total": 36
+        },
+        "abortion": {
+          "Democratic": 13,
+          "Republican": 0,
+          "total": 13
+        },
+        "capitol": {
+          "Democratic": 12,
+          "Republican": 4,
+          "total": 16
+        }
+      }
     },
     {
-        "state": "NE",
-        "Democratic": 11,
-        "Republican": 4,
-        "total": 15
+      "state": "OR",
+      "Democratic": 25,
+      "Republican": 14,
+      "total": 39,
+      "topic_breakdown": {
+        "climate": {
+          "Democratic": 20,
+          "Republican": 8,
+          "total": 28
+        },
+        "abortion": {
+          "Democratic": 12,
+          "Republican": 3,
+          "total": 15
+        },
+        "gun": {
+          "Democratic": 19,
+          "Republican": 4,
+          "total": 23
+        },
+        "immigra": {
+          "Democratic": 14,
+          "Republican": 3,
+          "total": 17
+        },
+        "covid": {
+          "Democratic": 25,
+          "Republican": 13,
+          "total": 38
+        },
+        "rights": {
+          "Democratic": 20,
+          "Republican": 7,
+          "total": 27
+        },
+        "capitol": {
+          "Democratic": 9,
+          "Republican": 4,
+          "total": 13
+        }
+      },
+      "legislator_breakdown": {
+        "climate": {
+          "Democratic": 20,
+          "Republican": 8,
+          "total": 28
+        },
+        "abortion": {
+          "Democratic": 12,
+          "Republican": 3,
+          "total": 15
+        },
+        "gun": {
+          "Democratic": 19,
+          "Republican": 4,
+          "total": 23
+        },
+        "immigra": {
+          "Democratic": 14,
+          "Republican": 3,
+          "total": 17
+        },
+        "covid": {
+          "Democratic": 25,
+          "Republican": 13,
+          "total": 38
+        },
+        "rights": {
+          "Democratic": 20,
+          "Republican": 7,
+          "total": 27
+        },
+        "capitol": {
+          "Democratic": 9,
+          "Republican": 4,
+          "total": 13
+        }
+      }
     },
     {
-        "state": "NH",
-        "Democratic": 78,
-        "Republican": 33,
-        "total": 111
+      "state": "AL",
+      "Democratic": 8,
+      "Republican": 30,
+      "total": 38,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 8,
+          "Republican": 29,
+          "total": 37
+        },
+        "gun": {
+          "Democratic": 5,
+          "Republican": 12,
+          "total": 17
+        },
+        "rights": {
+          "Democratic": 6,
+          "Republican": 13,
+          "total": 19
+        },
+        "climate": {
+          "Democratic": 1,
+          "Republican": 7,
+          "total": 8
+        },
+        "capitol": {
+          "Democratic": 1,
+          "Republican": 10,
+          "total": 11
+        },
+        "abortion": {
+          "Democratic": 2,
+          "Republican": 6,
+          "total": 8
+        },
+        "immigra": {
+          "Democratic": 1,
+          "Republican": 6,
+          "total": 7
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 8,
+          "Republican": 29,
+          "total": 37
+        },
+        "gun": {
+          "Democratic": 5,
+          "Republican": 12,
+          "total": 17
+        },
+        "rights": {
+          "Democratic": 6,
+          "Republican": 13,
+          "total": 19
+        },
+        "climate": {
+          "Democratic": 1,
+          "Republican": 7,
+          "total": 8
+        },
+        "capitol": {
+          "Democratic": 1,
+          "Republican": 10,
+          "total": 11
+        },
+        "abortion": {
+          "Democratic": 2,
+          "Republican": 6,
+          "total": 8
+        },
+        "immigra": {
+          "Democratic": 1,
+          "Republican": 6,
+          "total": 7
+        }
+      }
     },
     {
-        "state": "NJ",
-        "Democratic": 36,
-        "Republican": 22,
-        "total": 58
+      "state": "NC",
+      "Democratic": 52,
+      "Republican": 37,
+      "total": 89,
+      "topic_breakdown": {
+        "climate": {
+          "Democratic": 30,
+          "Republican": 14,
+          "total": 44
+        },
+        "covid": {
+          "Democratic": 51,
+          "Republican": 34,
+          "total": 85
+        },
+        "rights": {
+          "Democratic": 41,
+          "Republican": 17,
+          "total": 58
+        },
+        "immigra": {
+          "Democratic": 22,
+          "Republican": 6,
+          "total": 28
+        },
+        "gun": {
+          "Democratic": 34,
+          "Republican": 12,
+          "total": 46
+        },
+        "capitol": {
+          "Democratic": 22,
+          "Republican": 9,
+          "total": 31
+        },
+        "abortion": {
+          "Democratic": 20,
+          "Republican": 3,
+          "total": 23
+        }
+      },
+      "legislator_breakdown": {
+        "climate": {
+          "Democratic": 30,
+          "Republican": 14,
+          "total": 44
+        },
+        "covid": {
+          "Democratic": 51,
+          "Republican": 34,
+          "total": 85
+        },
+        "rights": {
+          "Democratic": 41,
+          "Republican": 17,
+          "total": 58
+        },
+        "immigra": {
+          "Democratic": 22,
+          "Republican": 6,
+          "total": 28
+        },
+        "gun": {
+          "Democratic": 34,
+          "Republican": 12,
+          "total": 46
+        },
+        "capitol": {
+          "Democratic": 22,
+          "Republican": 9,
+          "total": 31
+        },
+        "abortion": {
+          "Democratic": 20,
+          "Republican": 3,
+          "total": 23
+        }
+      }
     },
     {
-        "state": "NM",
-        "Democratic": 27,
-        "Republican": 11,
-        "total": 38
+      "state": "IL",
+      "Democratic": 44,
+      "Republican": 23,
+      "total": 67,
+      "topic_breakdown": {
+        "immigra": {
+          "Democratic": 16,
+          "Republican": 5,
+          "total": 21
+        },
+        "abortion": {
+          "Democratic": 6,
+          "Republican": 7,
+          "total": 13
+        },
+        "gun": {
+          "Democratic": 22,
+          "Republican": 6,
+          "total": 28
+        },
+        "climate": {
+          "Democratic": 23,
+          "Republican": 6,
+          "total": 29
+        },
+        "covid": {
+          "Democratic": 39,
+          "Republican": 21,
+          "total": 60
+        },
+        "rights": {
+          "Democratic": 30,
+          "Republican": 11,
+          "total": 41
+        },
+        "capitol": {
+          "Democratic": 10,
+          "Republican": 7,
+          "total": 17
+        }
+      },
+      "legislator_breakdown": {
+        "immigra": {
+          "Democratic": 16,
+          "Republican": 5,
+          "total": 21
+        },
+        "abortion": {
+          "Democratic": 6,
+          "Republican": 7,
+          "total": 13
+        },
+        "gun": {
+          "Democratic": 22,
+          "Republican": 6,
+          "total": 28
+        },
+        "climate": {
+          "Democratic": 23,
+          "Republican": 6,
+          "total": 29
+        },
+        "covid": {
+          "Democratic": 39,
+          "Republican": 21,
+          "total": 60
+        },
+        "rights": {
+          "Democratic": 30,
+          "Republican": 11,
+          "total": 41
+        },
+        "capitol": {
+          "Democratic": 10,
+          "Republican": 7,
+          "total": 17
+        }
+      }
     },
     {
-        "state": "NV",
-        "Democratic": 30,
-        "Republican": 13,
-        "total": 43
+      "state": "NM",
+      "Democratic": 27,
+      "Republican": 11,
+      "total": 38,
+      "topic_breakdown": {
+        "gun": {
+          "Democratic": 18,
+          "Republican": 7,
+          "total": 25
+        },
+        "capitol": {
+          "Democratic": 13,
+          "Republican": 1,
+          "total": 14
+        },
+        "rights": {
+          "Democratic": 23,
+          "Republican": 7,
+          "total": 30
+        },
+        "covid": {
+          "Democratic": 27,
+          "Republican": 9,
+          "total": 36
+        },
+        "abortion": {
+          "Democratic": 17,
+          "Republican": 4,
+          "total": 21
+        },
+        "climate": {
+          "Democratic": 17,
+          "Republican": 0,
+          "total": 17
+        },
+        "immigra": {
+          "Democratic": 17,
+          "Republican": 1,
+          "total": 18
+        }
+      },
+      "legislator_breakdown": {
+        "gun": {
+          "Democratic": 18,
+          "Republican": 7,
+          "total": 25
+        },
+        "capitol": {
+          "Democratic": 13,
+          "Republican": 1,
+          "total": 14
+        },
+        "rights": {
+          "Democratic": 23,
+          "Republican": 7,
+          "total": 30
+        },
+        "covid": {
+          "Democratic": 27,
+          "Republican": 9,
+          "total": 36
+        },
+        "abortion": {
+          "Democratic": 17,
+          "Republican": 4,
+          "total": 21
+        },
+        "climate": {
+          "Democratic": 17,
+          "Republican": 0,
+          "total": 17
+        },
+        "immigra": {
+          "Democratic": 17,
+          "Republican": 1,
+          "total": 18
+        }
+      }
     },
     {
-        "state": "NY",
-        "Democratic": 103,
-        "Republican": 34,
-        "total": 137
+      "state": "MD",
+      "Democratic": 71,
+      "Republican": 17,
+      "total": 88,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 67,
+          "Republican": 17,
+          "total": 84
+        },
+        "rights": {
+          "Democratic": 52,
+          "Republican": 12,
+          "total": 64
+        },
+        "gun": {
+          "Democratic": 51,
+          "Republican": 11,
+          "total": 62
+        },
+        "immigra": {
+          "Democratic": 40,
+          "Republican": 8,
+          "total": 48
+        },
+        "climate": {
+          "Democratic": 42,
+          "Republican": 5,
+          "total": 47
+        },
+        "abortion": {
+          "Democratic": 21,
+          "Republican": 6,
+          "total": 27
+        },
+        "capitol": {
+          "Democratic": 31,
+          "Republican": 6,
+          "total": 37
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 67,
+          "Republican": 17,
+          "total": 84
+        },
+        "rights": {
+          "Democratic": 52,
+          "Republican": 12,
+          "total": 64
+        },
+        "gun": {
+          "Democratic": 51,
+          "Republican": 11,
+          "total": 62
+        },
+        "immigra": {
+          "Democratic": 40,
+          "Republican": 8,
+          "total": 48
+        },
+        "climate": {
+          "Democratic": 42,
+          "Republican": 5,
+          "total": 47
+        },
+        "abortion": {
+          "Democratic": 21,
+          "Republican": 6,
+          "total": 27
+        },
+        "capitol": {
+          "Democratic": 31,
+          "Republican": 6,
+          "total": 37
+        }
+      }
     },
     {
-        "state": "OH",
-        "Democratic": 27,
-        "Republican": 44,
-        "total": 71
+      "state": "WV",
+      "Democratic": 21,
+      "Republican": 18,
+      "total": 39,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 21,
+          "Republican": 16,
+          "total": 37
+        },
+        "gun": {
+          "Democratic": 5,
+          "Republican": 9,
+          "total": 14
+        },
+        "rights": {
+          "Democratic": 5,
+          "Republican": 12,
+          "total": 17
+        },
+        "immigra": {
+          "Democratic": 2,
+          "Republican": 4,
+          "total": 6
+        },
+        "capitol": {
+          "Democratic": 9,
+          "Republican": 8,
+          "total": 17
+        },
+        "abortion": {
+          "Democratic": 3,
+          "Republican": 6,
+          "total": 9
+        },
+        "climate": {
+          "Democratic": 5,
+          "Republican": 6,
+          "total": 11
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 21,
+          "Republican": 16,
+          "total": 37
+        },
+        "gun": {
+          "Democratic": 5,
+          "Republican": 9,
+          "total": 14
+        },
+        "rights": {
+          "Democratic": 5,
+          "Republican": 12,
+          "total": 17
+        },
+        "immigra": {
+          "Democratic": 2,
+          "Republican": 4,
+          "total": 6
+        },
+        "capitol": {
+          "Democratic": 9,
+          "Republican": 8,
+          "total": 17
+        },
+        "abortion": {
+          "Democratic": 3,
+          "Republican": 6,
+          "total": 9
+        },
+        "climate": {
+          "Democratic": 5,
+          "Republican": 6,
+          "total": 11
+        }
+      }
     },
     {
-        "state": "OK",
-        "Democratic": 18,
-        "Republican": 35,
-        "total": 53
+      "state": "AZ",
+      "Democratic": 36,
+      "Republican": 30,
+      "total": 66,
+      "topic_breakdown": {
+        "gun": {
+          "Democratic": 31,
+          "Republican": 17,
+          "total": 48
+        },
+        "covid": {
+          "Democratic": 35,
+          "Republican": 29,
+          "total": 64
+        },
+        "climate": {
+          "Democratic": 30,
+          "Republican": 18,
+          "total": 48
+        },
+        "rights": {
+          "Democratic": 33,
+          "Republican": 27,
+          "total": 60
+        },
+        "abortion": {
+          "Democratic": 23,
+          "Republican": 18,
+          "total": 41
+        },
+        "immigra": {
+          "Democratic": 28,
+          "Republican": 15,
+          "total": 43
+        },
+        "capitol": {
+          "Democratic": 25,
+          "Republican": 18,
+          "total": 43
+        }
+      },
+      "legislator_breakdown": {
+        "gun": {
+          "Democratic": 31,
+          "Republican": 17,
+          "total": 48
+        },
+        "covid": {
+          "Democratic": 35,
+          "Republican": 29,
+          "total": 64
+        },
+        "climate": {
+          "Democratic": 30,
+          "Republican": 18,
+          "total": 48
+        },
+        "rights": {
+          "Democratic": 33,
+          "Republican": 27,
+          "total": 60
+        },
+        "abortion": {
+          "Democratic": 23,
+          "Republican": 18,
+          "total": 41
+        },
+        "immigra": {
+          "Democratic": 28,
+          "Republican": 15,
+          "total": 43
+        },
+        "capitol": {
+          "Democratic": 25,
+          "Republican": 18,
+          "total": 43
+        }
+      }
     },
     {
-        "state": "OR",
-        "Democratic": 25,
-        "Republican": 14,
-        "total": 39
+      "state": "WI",
+      "Democratic": 30,
+      "Republican": 29,
+      "total": 59,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 30,
+          "Republican": 28,
+          "total": 58
+        },
+        "rights": {
+          "Democratic": 20,
+          "Republican": 20,
+          "total": 40
+        },
+        "abortion": {
+          "Democratic": 8,
+          "Republican": 6,
+          "total": 14
+        },
+        "climate": {
+          "Democratic": 17,
+          "Republican": 8,
+          "total": 25
+        },
+        "immigra": {
+          "Democratic": 13,
+          "Republican": 11,
+          "total": 24
+        },
+        "gun": {
+          "Democratic": 16,
+          "Republican": 15,
+          "total": 31
+        },
+        "capitol": {
+          "Democratic": 13,
+          "Republican": 14,
+          "total": 27
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 30,
+          "Republican": 28,
+          "total": 58
+        },
+        "rights": {
+          "Democratic": 20,
+          "Republican": 20,
+          "total": 40
+        },
+        "abortion": {
+          "Democratic": 8,
+          "Republican": 6,
+          "total": 14
+        },
+        "climate": {
+          "Democratic": 17,
+          "Republican": 8,
+          "total": 25
+        },
+        "immigra": {
+          "Democratic": 13,
+          "Republican": 11,
+          "total": 24
+        },
+        "gun": {
+          "Democratic": 16,
+          "Republican": 15,
+          "total": 31
+        },
+        "capitol": {
+          "Democratic": 13,
+          "Republican": 14,
+          "total": 27
+        }
+      }
     },
     {
-        "state": "PA",
-        "Democratic": 66,
-        "Republican": 36,
-        "total": 102
+      "state": "ME",
+      "Democratic": 34,
+      "Republican": 5,
+      "total": 39,
+      "topic_breakdown": {
+        "capitol": {
+          "Democratic": 12,
+          "Republican": 2,
+          "total": 14
+        },
+        "rights": {
+          "Democratic": 20,
+          "Republican": 2,
+          "total": 22
+        },
+        "gun": {
+          "Democratic": 8,
+          "Republican": 2,
+          "total": 10
+        },
+        "covid": {
+          "Democratic": 31,
+          "Republican": 3,
+          "total": 34
+        },
+        "abortion": {
+          "Democratic": 11,
+          "Republican": 0,
+          "total": 11
+        },
+        "climate": {
+          "Democratic": 21,
+          "Republican": 1,
+          "total": 22
+        },
+        "immigra": {
+          "Democratic": 4,
+          "Republican": 0,
+          "total": 4
+        }
+      },
+      "legislator_breakdown": {
+        "capitol": {
+          "Democratic": 12,
+          "Republican": 2,
+          "total": 14
+        },
+        "rights": {
+          "Democratic": 20,
+          "Republican": 2,
+          "total": 22
+        },
+        "gun": {
+          "Democratic": 8,
+          "Republican": 2,
+          "total": 10
+        },
+        "covid": {
+          "Democratic": 31,
+          "Republican": 3,
+          "total": 34
+        },
+        "abortion": {
+          "Democratic": 11,
+          "Republican": 0,
+          "total": 11
+        },
+        "climate": {
+          "Democratic": 21,
+          "Republican": 1,
+          "total": 22
+        },
+        "immigra": {
+          "Democratic": 4,
+          "Republican": 0,
+          "total": 4
+        }
+      }
     },
     {
-        "state": "RI",
-        "Democratic": 45,
-        "Republican": 8,
-        "total": 53
+      "state": "VT",
+      "Democratic": 26,
+      "Republican": 3,
+      "total": 29,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 22,
+          "Republican": 3,
+          "total": 25
+        },
+        "climate": {
+          "Democratic": 14,
+          "Republican": 0,
+          "total": 14
+        },
+        "gun": {
+          "Democratic": 5,
+          "Republican": 0,
+          "total": 5
+        },
+        "capitol": {
+          "Democratic": 5,
+          "Republican": 0,
+          "total": 5
+        },
+        "rights": {
+          "Democratic": 14,
+          "Republican": 1,
+          "total": 15
+        },
+        "immigra": {
+          "Democratic": 4,
+          "Republican": 0,
+          "total": 4
+        },
+        "abortion": {
+          "Democratic": 7,
+          "Republican": 0,
+          "total": 7
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 22,
+          "Republican": 3,
+          "total": 25
+        },
+        "climate": {
+          "Democratic": 14,
+          "Republican": 0,
+          "total": 14
+        },
+        "gun": {
+          "Democratic": 5,
+          "Republican": 0,
+          "total": 5
+        },
+        "capitol": {
+          "Democratic": 5,
+          "Republican": 0,
+          "total": 5
+        },
+        "rights": {
+          "Democratic": 14,
+          "Republican": 1,
+          "total": 15
+        },
+        "immigra": {
+          "Democratic": 4,
+          "Republican": 0,
+          "total": 4
+        },
+        "abortion": {
+          "Democratic": 7,
+          "Republican": 0,
+          "total": 7
+        }
+      }
     },
     {
-        "state": "SC",
-        "Democratic": 26,
-        "Republican": 43,
-        "total": 69
+      "state": "OK",
+      "Democratic": 18,
+      "Republican": 35,
+      "total": 53,
+      "topic_breakdown": {
+        "rights": {
+          "Democratic": 15,
+          "Republican": 16,
+          "total": 31
+        },
+        "gun": {
+          "Democratic": 13,
+          "Republican": 9,
+          "total": 22
+        },
+        "capitol": {
+          "Democratic": 9,
+          "Republican": 7,
+          "total": 16
+        },
+        "covid": {
+          "Democratic": 17,
+          "Republican": 32,
+          "total": 49
+        },
+        "abortion": {
+          "Democratic": 7,
+          "Republican": 3,
+          "total": 10
+        },
+        "immigra": {
+          "Democratic": 8,
+          "Republican": 5,
+          "total": 13
+        },
+        "climate": {
+          "Democratic": 7,
+          "Republican": 3,
+          "total": 10
+        }
+      },
+      "legislator_breakdown": {
+        "rights": {
+          "Democratic": 15,
+          "Republican": 16,
+          "total": 31
+        },
+        "gun": {
+          "Democratic": 13,
+          "Republican": 9,
+          "total": 22
+        },
+        "capitol": {
+          "Democratic": 9,
+          "Republican": 7,
+          "total": 16
+        },
+        "covid": {
+          "Democratic": 17,
+          "Republican": 32,
+          "total": 49
+        },
+        "abortion": {
+          "Democratic": 7,
+          "Republican": 3,
+          "total": 10
+        },
+        "immigra": {
+          "Democratic": 8,
+          "Republican": 5,
+          "total": 13
+        },
+        "climate": {
+          "Democratic": 7,
+          "Republican": 3,
+          "total": 10
+        }
+      }
     },
     {
-        "state": "SD",
-        "Democratic": 3,
-        "Republican": 11,
-        "total": 14
+      "state": "TN",
+      "Democratic": 15,
+      "Republican": 42,
+      "total": 57,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 9,
+          "Republican": 16,
+          "total": 25
+        },
+        "gun": {
+          "Democratic": 11,
+          "Republican": 23,
+          "total": 34
+        },
+        "rights": {
+          "Democratic": 13,
+          "Republican": 32,
+          "total": 45
+        },
+        "covid": {
+          "Democratic": 15,
+          "Republican": 40,
+          "total": 55
+        },
+        "climate": {
+          "Democratic": 4,
+          "Republican": 12,
+          "total": 16
+        },
+        "capitol": {
+          "Democratic": 11,
+          "Republican": 12,
+          "total": 23
+        },
+        "immigra": {
+          "Democratic": 7,
+          "Republican": 13,
+          "total": 20
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 9,
+          "Republican": 16,
+          "total": 25
+        },
+        "gun": {
+          "Democratic": 11,
+          "Republican": 23,
+          "total": 34
+        },
+        "rights": {
+          "Democratic": 13,
+          "Republican": 32,
+          "total": 45
+        },
+        "covid": {
+          "Democratic": 15,
+          "Republican": 40,
+          "total": 55
+        },
+        "climate": {
+          "Democratic": 4,
+          "Republican": 12,
+          "total": 16
+        },
+        "capitol": {
+          "Democratic": 11,
+          "Republican": 12,
+          "total": 23
+        },
+        "immigra": {
+          "Democratic": 7,
+          "Republican": 13,
+          "total": 20
+        }
+      }
     },
     {
-        "state": "TN",
-        "Democratic": 15,
-        "Republican": 42,
-        "total": 57
+      "state": "GA",
+      "Democratic": 52,
+      "Republican": 46,
+      "total": 98,
+      "topic_breakdown": {
+        "rights": {
+          "Democratic": 45,
+          "Republican": 26,
+          "total": 71
+        },
+        "covid": {
+          "Democratic": 52,
+          "Republican": 44,
+          "total": 96
+        },
+        "gun": {
+          "Democratic": 29,
+          "Republican": 15,
+          "total": 44
+        },
+        "immigra": {
+          "Democratic": 24,
+          "Republican": 11,
+          "total": 35
+        },
+        "climate": {
+          "Democratic": 20,
+          "Republican": 6,
+          "total": 26
+        },
+        "capitol": {
+          "Democratic": 32,
+          "Republican": 15,
+          "total": 47
+        },
+        "abortion": {
+          "Democratic": 19,
+          "Republican": 9,
+          "total": 28
+        }
+      },
+      "legislator_breakdown": {
+        "rights": {
+          "Democratic": 45,
+          "Republican": 26,
+          "total": 71
+        },
+        "covid": {
+          "Democratic": 52,
+          "Republican": 44,
+          "total": 96
+        },
+        "gun": {
+          "Democratic": 29,
+          "Republican": 15,
+          "total": 44
+        },
+        "immigra": {
+          "Democratic": 24,
+          "Republican": 11,
+          "total": 35
+        },
+        "climate": {
+          "Democratic": 20,
+          "Republican": 6,
+          "total": 26
+        },
+        "capitol": {
+          "Democratic": 32,
+          "Republican": 15,
+          "total": 47
+        },
+        "abortion": {
+          "Democratic": 19,
+          "Republican": 9,
+          "total": 28
+        }
+      }
     },
     {
-        "state": "TX",
-        "Democratic": 53,
-        "Republican": 81,
-        "total": 134
+      "state": "WY",
+      "Democratic": 5,
+      "Republican": 11,
+      "total": 16,
+      "topic_breakdown": {
+        "gun": {
+          "Democratic": 2,
+          "Republican": 6,
+          "total": 8
+        },
+        "covid": {
+          "Democratic": 5,
+          "Republican": 10,
+          "total": 15
+        },
+        "rights": {
+          "Democratic": 2,
+          "Republican": 9,
+          "total": 11
+        },
+        "capitol": {
+          "Democratic": 1,
+          "Republican": 3,
+          "total": 4
+        },
+        "abortion": {
+          "Democratic": 3,
+          "Republican": 5,
+          "total": 8
+        },
+        "immigra": {
+          "Democratic": 1,
+          "Republican": 3,
+          "total": 4
+        },
+        "climate": {
+          "Democratic": 3,
+          "Republican": 2,
+          "total": 5
+        }
+      },
+      "legislator_breakdown": {
+        "gun": {
+          "Democratic": 2,
+          "Republican": 6,
+          "total": 8
+        },
+        "covid": {
+          "Democratic": 5,
+          "Republican": 10,
+          "total": 15
+        },
+        "rights": {
+          "Democratic": 2,
+          "Republican": 9,
+          "total": 11
+        },
+        "capitol": {
+          "Democratic": 1,
+          "Republican": 3,
+          "total": 4
+        },
+        "abortion": {
+          "Democratic": 3,
+          "Republican": 5,
+          "total": 8
+        },
+        "immigra": {
+          "Democratic": 1,
+          "Republican": 3,
+          "total": 4
+        },
+        "climate": {
+          "Democratic": 3,
+          "Republican": 2,
+          "total": 5
+        }
+      }
     },
     {
-        "state": "UT",
-        "Democratic": 15,
-        "Republican": 32,
-        "total": 47
+      "state": "AK",
+      "Democratic": 9,
+      "Republican": 6,
+      "total": 15,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 9,
+          "Republican": 6,
+          "total": 15
+        },
+        "climate": {
+          "Democratic": 4,
+          "Republican": 0,
+          "total": 4
+        },
+        "rights": {
+          "Democratic": 8,
+          "Republican": 0,
+          "total": 8
+        },
+        "capitol": {
+          "Democratic": 4,
+          "Republican": 1,
+          "total": 5
+        },
+        "gun": {
+          "Democratic": 3,
+          "Republican": 0,
+          "total": 3
+        },
+        "immigra": {
+          "Democratic": 1,
+          "Republican": 0,
+          "total": 1
+        },
+        "abortion": {
+          "Democratic": 1,
+          "Republican": 0,
+          "total": 1
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 9,
+          "Republican": 6,
+          "total": 15
+        },
+        "climate": {
+          "Democratic": 4,
+          "Republican": 0,
+          "total": 4
+        },
+        "rights": {
+          "Democratic": 8,
+          "Republican": 0,
+          "total": 8
+        },
+        "capitol": {
+          "Democratic": 4,
+          "Republican": 1,
+          "total": 5
+        },
+        "gun": {
+          "Democratic": 3,
+          "Republican": 0,
+          "total": 3
+        },
+        "immigra": {
+          "Democratic": 1,
+          "Republican": 0,
+          "total": 1
+        },
+        "abortion": {
+          "Democratic": 1,
+          "Republican": 0,
+          "total": 1
+        }
+      }
     },
     {
-        "state": "VA",
-        "Democratic": 51,
-        "Republican": 24,
-        "total": 75
+      "state": "SD",
+      "Democratic": 3,
+      "Republican": 11,
+      "total": 14,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 3,
+          "Republican": 10,
+          "total": 13
+        },
+        "rights": {
+          "Democratic": 3,
+          "Republican": 5,
+          "total": 8
+        },
+        "gun": {
+          "Democratic": 2,
+          "Republican": 4,
+          "total": 6
+        },
+        "abortion": {
+          "Democratic": 1,
+          "Republican": 4,
+          "total": 5
+        },
+        "immigra": {
+          "Democratic": 2,
+          "Republican": 1,
+          "total": 3
+        },
+        "climate": {
+          "Democratic": 2,
+          "Republican": 2,
+          "total": 4
+        },
+        "capitol": {
+          "Democratic": 3,
+          "Republican": 0,
+          "total": 3
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 3,
+          "Republican": 10,
+          "total": 13
+        },
+        "rights": {
+          "Democratic": 3,
+          "Republican": 5,
+          "total": 8
+        },
+        "gun": {
+          "Democratic": 2,
+          "Republican": 4,
+          "total": 6
+        },
+        "abortion": {
+          "Democratic": 1,
+          "Republican": 4,
+          "total": 5
+        },
+        "immigra": {
+          "Democratic": 2,
+          "Republican": 1,
+          "total": 3
+        },
+        "climate": {
+          "Democratic": 2,
+          "Republican": 2,
+          "total": 4
+        },
+        "capitol": {
+          "Democratic": 3,
+          "Republican": 0,
+          "total": 3
+        }
+      }
     },
     {
-        "state": "VT",
-        "Democratic": 26,
-        "Republican": 3,
-        "total": 29
+      "state": "ID",
+      "Democratic": 9,
+      "Republican": 11,
+      "total": 20,
+      "topic_breakdown": {
+        "capitol": {
+          "Democratic": 4,
+          "Republican": 4,
+          "total": 8
+        },
+        "covid": {
+          "Democratic": 9,
+          "Republican": 10,
+          "total": 19
+        },
+        "climate": {
+          "Democratic": 7,
+          "Republican": 2,
+          "total": 9
+        },
+        "immigra": {
+          "Democratic": 3,
+          "Republican": 2,
+          "total": 5
+        },
+        "rights": {
+          "Democratic": 8,
+          "Republican": 8,
+          "total": 16
+        },
+        "abortion": {
+          "Democratic": 3,
+          "Republican": 1,
+          "total": 4
+        },
+        "gun": {
+          "Democratic": 6,
+          "Republican": 4,
+          "total": 10
+        }
+      },
+      "legislator_breakdown": {
+        "capitol": {
+          "Democratic": 4,
+          "Republican": 4,
+          "total": 8
+        },
+        "covid": {
+          "Democratic": 9,
+          "Republican": 10,
+          "total": 19
+        },
+        "climate": {
+          "Democratic": 7,
+          "Republican": 2,
+          "total": 9
+        },
+        "immigra": {
+          "Democratic": 3,
+          "Republican": 2,
+          "total": 5
+        },
+        "rights": {
+          "Democratic": 8,
+          "Republican": 8,
+          "total": 16
+        },
+        "abortion": {
+          "Democratic": 3,
+          "Republican": 1,
+          "total": 4
+        },
+        "gun": {
+          "Democratic": 6,
+          "Republican": 4,
+          "total": 10
+        }
+      }
     },
     {
-        "state": "WA",
-        "Democratic": 40,
-        "Republican": 16,
-        "total": 56
+      "state": "MS",
+      "Democratic": 7,
+      "Republican": 27,
+      "total": 34,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 7,
+          "Republican": 26,
+          "total": 33
+        },
+        "gun": {
+          "Democratic": 4,
+          "Republican": 14,
+          "total": 18
+        },
+        "capitol": {
+          "Democratic": 4,
+          "Republican": 6,
+          "total": 10
+        },
+        "rights": {
+          "Democratic": 4,
+          "Republican": 6,
+          "total": 10
+        },
+        "abortion": {
+          "Democratic": 1,
+          "Republican": 6,
+          "total": 7
+        },
+        "immigra": {
+          "Democratic": 3,
+          "Republican": 2,
+          "total": 5
+        },
+        "climate": {
+          "Democratic": 0,
+          "Republican": 1,
+          "total": 1
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 7,
+          "Republican": 26,
+          "total": 33
+        },
+        "gun": {
+          "Democratic": 4,
+          "Republican": 14,
+          "total": 18
+        },
+        "capitol": {
+          "Democratic": 4,
+          "Republican": 6,
+          "total": 10
+        },
+        "rights": {
+          "Democratic": 4,
+          "Republican": 6,
+          "total": 10
+        },
+        "abortion": {
+          "Democratic": 1,
+          "Republican": 6,
+          "total": 7
+        },
+        "immigra": {
+          "Democratic": 3,
+          "Republican": 2,
+          "total": 5
+        },
+        "climate": {
+          "Democratic": 0,
+          "Republican": 1,
+          "total": 1
+        }
+      }
     },
     {
-        "state": "WI",
-        "Democratic": 30,
-        "Republican": 29,
-        "total": 59
+      "state": "DE",
+      "Democratic": 9,
+      "Republican": 2,
+      "total": 11,
+      "topic_breakdown": {
+        "gun": {
+          "Democratic": 7,
+          "Republican": 1,
+          "total": 8
+        },
+        "climate": {
+          "Democratic": 5,
+          "Republican": 0,
+          "total": 5
+        },
+        "rights": {
+          "Democratic": 8,
+          "Republican": 0,
+          "total": 8
+        },
+        "covid": {
+          "Democratic": 9,
+          "Republican": 1,
+          "total": 10
+        },
+        "capitol": {
+          "Democratic": 3,
+          "Republican": 0,
+          "total": 3
+        },
+        "abortion": {
+          "Democratic": 7,
+          "Republican": 0,
+          "total": 7
+        },
+        "immigra": {
+          "Democratic": 4,
+          "Republican": 0,
+          "total": 4
+        }
+      },
+      "legislator_breakdown": {
+        "gun": {
+          "Democratic": 7,
+          "Republican": 1,
+          "total": 8
+        },
+        "climate": {
+          "Democratic": 5,
+          "Republican": 0,
+          "total": 5
+        },
+        "rights": {
+          "Democratic": 8,
+          "Republican": 0,
+          "total": 8
+        },
+        "covid": {
+          "Democratic": 9,
+          "Republican": 1,
+          "total": 10
+        },
+        "capitol": {
+          "Democratic": 3,
+          "Republican": 0,
+          "total": 3
+        },
+        "abortion": {
+          "Democratic": 7,
+          "Republican": 0,
+          "total": 7
+        },
+        "immigra": {
+          "Democratic": 4,
+          "Republican": 0,
+          "total": 4
+        }
+      }
     },
     {
-        "state": "WV",
-        "Democratic": 21,
-        "Republican": 18,
-        "total": 39
+      "state": "NV",
+      "Democratic": 30,
+      "Republican": 13,
+      "total": 43,
+      "topic_breakdown": {
+        "covid": {
+          "Democratic": 30,
+          "Republican": 13,
+          "total": 43
+        },
+        "climate": {
+          "Democratic": 16,
+          "Republican": 3,
+          "total": 19
+        },
+        "gun": {
+          "Democratic": 17,
+          "Republican": 7,
+          "total": 24
+        },
+        "rights": {
+          "Democratic": 23,
+          "Republican": 10,
+          "total": 33
+        },
+        "immigra": {
+          "Democratic": 16,
+          "Republican": 2,
+          "total": 18
+        },
+        "capitol": {
+          "Democratic": 12,
+          "Republican": 4,
+          "total": 16
+        },
+        "abortion": {
+          "Democratic": 10,
+          "Republican": 2,
+          "total": 12
+        }
+      },
+      "legislator_breakdown": {
+        "covid": {
+          "Democratic": 30,
+          "Republican": 13,
+          "total": 43
+        },
+        "climate": {
+          "Democratic": 16,
+          "Republican": 3,
+          "total": 19
+        },
+        "gun": {
+          "Democratic": 17,
+          "Republican": 7,
+          "total": 24
+        },
+        "rights": {
+          "Democratic": 23,
+          "Republican": 10,
+          "total": 33
+        },
+        "immigra": {
+          "Democratic": 16,
+          "Republican": 2,
+          "total": 18
+        },
+        "capitol": {
+          "Democratic": 12,
+          "Republican": 4,
+          "total": 16
+        },
+        "abortion": {
+          "Democratic": 10,
+          "Republican": 2,
+          "total": 12
+        }
+      }
     },
     {
-        "state": "WY",
-        "Democratic": 6,
-        "Republican": 11,
-        "total": 17
+      "state": "ND",
+      "Democratic": 5,
+      "Republican": 10,
+      "total": 15,
+      "topic_breakdown": {
+        "gun": {
+          "Democratic": 4,
+          "Republican": 5,
+          "total": 9
+        },
+        "covid": {
+          "Democratic": 5,
+          "Republican": 8,
+          "total": 13
+        },
+        "rights": {
+          "Democratic": 3,
+          "Republican": 3,
+          "total": 6
+        },
+        "climate": {
+          "Democratic": 3,
+          "Republican": 1,
+          "total": 4
+        },
+        "abortion": {
+          "Democratic": 2,
+          "Republican": 1,
+          "total": 3
+        },
+        "immigra": {
+          "Democratic": 3,
+          "Republican": 0,
+          "total": 3
+        },
+        "capitol": {
+          "Democratic": 2,
+          "Republican": 3,
+          "total": 5
+        }
+      },
+      "legislator_breakdown": {
+        "gun": {
+          "Democratic": 4,
+          "Republican": 5,
+          "total": 9
+        },
+        "covid": {
+          "Democratic": 5,
+          "Republican": 8,
+          "total": 13
+        },
+        "rights": {
+          "Democratic": 3,
+          "Republican": 3,
+          "total": 6
+        },
+        "climate": {
+          "Democratic": 3,
+          "Republican": 1,
+          "total": 4
+        },
+        "abortion": {
+          "Democratic": 2,
+          "Republican": 1,
+          "total": 3
+        },
+        "immigra": {
+          "Democratic": 3,
+          "Republican": 0,
+          "total": 3
+        },
+        "capitol": {
+          "Democratic": 2,
+          "Republican": 3,
+          "total": 5
+        }
+      }
     }
-]
+  ]

--- a/civicwatch_backend/static/data/defaultChoroplethPosts.json
+++ b/civicwatch_backend/static/data/defaultChoroplethPosts.json
@@ -1,302 +1,4002 @@
 [
     {
-        "state": "AK",
-        "Democratic": 449,
-        "Republican": 18,
-        "total": 467
+      "state": "AK",
+      "Democratic": 445,
+      "Republican": 17,
+      "total": 462,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 1,
+          "Republican": 0,
+          "total": 1
+        },
+        "capitol": {
+          "Democratic": 8,
+          "Republican": 1,
+          "total": 9
+        },
+        "climate": {
+          "Democratic": 10,
+          "Republican": 0,
+          "total": 10
+        },
+        "covid": {
+          "Democratic": 383,
+          "Republican": 16,
+          "total": 399
+        },
+        "gun": {
+          "Democratic": 5,
+          "Republican": 0,
+          "total": 5
+        },
+        "immigra": {
+          "Democratic": 1,
+          "Republican": 0,
+          "total": 1
+        },
+        "rights": {
+          "Democratic": 37,
+          "Republican": 0,
+          "total": 37
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 1,
+          "Republican": 0,
+          "total": 1
+        },
+        "capitol": {
+          "Democratic": 8,
+          "Republican": 1,
+          "total": 9
+        },
+        "climate": {
+          "Democratic": 10,
+          "Republican": 0,
+          "total": 10
+        },
+        "covid": {
+          "Democratic": 383,
+          "Republican": 16,
+          "total": 399
+        },
+        "gun": {
+          "Democratic": 5,
+          "Republican": 0,
+          "total": 5
+        },
+        "immigra": {
+          "Democratic": 1,
+          "Republican": 0,
+          "total": 1
+        },
+        "rights": {
+          "Democratic": 37,
+          "Republican": 0,
+          "total": 37
+        }
+      }
     },
     {
-        "state": "AL",
-        "Democratic": 284,
-        "Republican": 1453,
-        "total": 1737
+      "state": "AL",
+      "Democratic": 264,
+      "Republican": 1376,
+      "total": 1640,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 4,
+          "Republican": 122,
+          "total": 126
+        },
+        "capitol": {
+          "Democratic": 7,
+          "Republican": 28,
+          "total": 35
+        },
+        "climate": {
+          "Democratic": 1,
+          "Republican": 25,
+          "total": 26
+        },
+        "covid": {
+          "Democratic": 206,
+          "Republican": 929,
+          "total": 1135
+        },
+        "gun": {
+          "Democratic": 16,
+          "Republican": 128,
+          "total": 144
+        },
+        "immigra": {
+          "Democratic": 1,
+          "Republican": 69,
+          "total": 70
+        },
+        "rights": {
+          "Democratic": 29,
+          "Republican": 75,
+          "total": 104
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 4,
+          "Republican": 122,
+          "total": 126
+        },
+        "capitol": {
+          "Democratic": 7,
+          "Republican": 28,
+          "total": 35
+        },
+        "climate": {
+          "Democratic": 1,
+          "Republican": 25,
+          "total": 26
+        },
+        "covid": {
+          "Democratic": 206,
+          "Republican": 929,
+          "total": 1135
+        },
+        "gun": {
+          "Democratic": 16,
+          "Republican": 128,
+          "total": 144
+        },
+        "immigra": {
+          "Democratic": 1,
+          "Republican": 69,
+          "total": 70
+        },
+        "rights": {
+          "Democratic": 29,
+          "Republican": 75,
+          "total": 104
+        }
+      }
     },
     {
-        "state": "AR",
-        "Democratic": 3150,
-        "Republican": 2362,
-        "total": 5512
+      "state": "AR",
+      "Democratic": 3090,
+      "Republican": 2297,
+      "total": 5387,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 28,
+          "Republican": 541,
+          "total": 569
+        },
+        "capitol": {
+          "Democratic": 29,
+          "Republican": 30,
+          "total": 59
+        },
+        "climate": {
+          "Democratic": 11,
+          "Republican": 18,
+          "total": 29
+        },
+        "covid": {
+          "Democratic": 2775,
+          "Republican": 1381,
+          "total": 4156
+        },
+        "gun": {
+          "Democratic": 65,
+          "Republican": 134,
+          "total": 199
+        },
+        "immigra": {
+          "Democratic": 17,
+          "Republican": 31,
+          "total": 48
+        },
+        "rights": {
+          "Democratic": 165,
+          "Republican": 162,
+          "total": 327
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 28,
+          "Republican": 541,
+          "total": 569
+        },
+        "capitol": {
+          "Democratic": 29,
+          "Republican": 30,
+          "total": 59
+        },
+        "climate": {
+          "Democratic": 11,
+          "Republican": 18,
+          "total": 29
+        },
+        "covid": {
+          "Democratic": 2775,
+          "Republican": 1381,
+          "total": 4156
+        },
+        "gun": {
+          "Democratic": 65,
+          "Republican": 134,
+          "total": 199
+        },
+        "immigra": {
+          "Democratic": 17,
+          "Republican": 31,
+          "total": 48
+        },
+        "rights": {
+          "Democratic": 165,
+          "Republican": 162,
+          "total": 327
+        }
+      }
     },
     {
-        "state": "AZ",
-        "Democratic": 12043,
-        "Republican": 5156,
-        "total": 17199
+      "state": "AZ",
+      "Democratic": 11767,
+      "Republican": 4954,
+      "total": 16721,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 754,
+          "Republican": 590,
+          "total": 1344
+        },
+        "capitol": {
+          "Democratic": 461,
+          "Republican": 272,
+          "total": 733
+        },
+        "climate": {
+          "Democratic": 643,
+          "Republican": 114,
+          "total": 757
+        },
+        "covid": {
+          "Democratic": 7582,
+          "Republican": 2534,
+          "total": 10116
+        },
+        "gun": {
+          "Democratic": 589,
+          "Republican": 554,
+          "total": 1143
+        },
+        "immigra": {
+          "Democratic": 398,
+          "Republican": 487,
+          "total": 885
+        },
+        "rights": {
+          "Democratic": 1340,
+          "Republican": 403,
+          "total": 1743
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 754,
+          "Republican": 590,
+          "total": 1344
+        },
+        "capitol": {
+          "Democratic": 461,
+          "Republican": 272,
+          "total": 733
+        },
+        "climate": {
+          "Democratic": 643,
+          "Republican": 114,
+          "total": 757
+        },
+        "covid": {
+          "Democratic": 7582,
+          "Republican": 2534,
+          "total": 10116
+        },
+        "gun": {
+          "Democratic": 589,
+          "Republican": 554,
+          "total": 1143
+        },
+        "immigra": {
+          "Democratic": 398,
+          "Republican": 487,
+          "total": 885
+        },
+        "rights": {
+          "Democratic": 1340,
+          "Republican": 403,
+          "total": 1743
+        }
+      }
     },
     {
-        "state": "CA",
-        "Democratic": 15437,
-        "Republican": 1723,
-        "total": 17160
+      "state": "CA",
+      "Democratic": 15012,
+      "Republican": 1680,
+      "total": 16692,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 167,
+          "Republican": 0,
+          "total": 167
+        },
+        "capitol": {
+          "Democratic": 70,
+          "Republican": 25,
+          "total": 95
+        },
+        "climate": {
+          "Democratic": 940,
+          "Republican": 69,
+          "total": 1009
+        },
+        "covid": {
+          "Democratic": 11709,
+          "Republican": 1446,
+          "total": 13155
+        },
+        "gun": {
+          "Democratic": 703,
+          "Republican": 28,
+          "total": 731
+        },
+        "immigra": {
+          "Democratic": 480,
+          "Republican": 17,
+          "total": 497
+        },
+        "rights": {
+          "Democratic": 943,
+          "Republican": 95,
+          "total": 1038
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 167,
+          "Republican": 0,
+          "total": 167
+        },
+        "capitol": {
+          "Democratic": 70,
+          "Republican": 25,
+          "total": 95
+        },
+        "climate": {
+          "Democratic": 940,
+          "Republican": 69,
+          "total": 1009
+        },
+        "covid": {
+          "Democratic": 11709,
+          "Republican": 1446,
+          "total": 13155
+        },
+        "gun": {
+          "Democratic": 703,
+          "Republican": 28,
+          "total": 731
+        },
+        "immigra": {
+          "Democratic": 480,
+          "Republican": 17,
+          "total": 497
+        },
+        "rights": {
+          "Democratic": 943,
+          "Republican": 95,
+          "total": 1038
+        }
+      }
     },
     {
-        "state": "CO",
-        "Democratic": 4354,
-        "Republican": 595,
-        "total": 4949
+      "state": "CO",
+      "Democratic": 4109,
+      "Republican": 464,
+      "total": 4573,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 87,
+          "Republican": 22,
+          "total": 109
+        },
+        "capitol": {
+          "Democratic": 155,
+          "Republican": 95,
+          "total": 250
+        },
+        "climate": {
+          "Democratic": 392,
+          "Republican": 10,
+          "total": 402
+        },
+        "covid": {
+          "Democratic": 2455,
+          "Republican": 244,
+          "total": 2699
+        },
+        "gun": {
+          "Democratic": 483,
+          "Republican": 44,
+          "total": 527
+        },
+        "immigra": {
+          "Democratic": 141,
+          "Republican": 14,
+          "total": 155
+        },
+        "rights": {
+          "Democratic": 396,
+          "Republican": 35,
+          "total": 431
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 87,
+          "Republican": 22,
+          "total": 109
+        },
+        "capitol": {
+          "Democratic": 155,
+          "Republican": 95,
+          "total": 250
+        },
+        "climate": {
+          "Democratic": 392,
+          "Republican": 10,
+          "total": 402
+        },
+        "covid": {
+          "Democratic": 2455,
+          "Republican": 244,
+          "total": 2699
+        },
+        "gun": {
+          "Democratic": 483,
+          "Republican": 44,
+          "total": 527
+        },
+        "immigra": {
+          "Democratic": 141,
+          "Republican": 14,
+          "total": 155
+        },
+        "rights": {
+          "Democratic": 396,
+          "Republican": 35,
+          "total": 431
+        }
+      }
     },
     {
-        "state": "CT",
-        "Democratic": 2372,
-        "Republican": 803,
-        "total": 3175
+      "state": "CT",
+      "Democratic": 2299,
+      "Republican": 785,
+      "total": 3084,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 16,
+          "Republican": 0,
+          "total": 16
+        },
+        "capitol": {
+          "Democratic": 36,
+          "Republican": 14,
+          "total": 50
+        },
+        "climate": {
+          "Democratic": 120,
+          "Republican": 5,
+          "total": 125
+        },
+        "covid": {
+          "Democratic": 1773,
+          "Republican": 737,
+          "total": 2510
+        },
+        "gun": {
+          "Democratic": 142,
+          "Republican": 7,
+          "total": 149
+        },
+        "immigra": {
+          "Democratic": 48,
+          "Republican": 1,
+          "total": 49
+        },
+        "rights": {
+          "Democratic": 164,
+          "Republican": 21,
+          "total": 185
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 16,
+          "Republican": 0,
+          "total": 16
+        },
+        "capitol": {
+          "Democratic": 36,
+          "Republican": 14,
+          "total": 50
+        },
+        "climate": {
+          "Democratic": 120,
+          "Republican": 5,
+          "total": 125
+        },
+        "covid": {
+          "Democratic": 1773,
+          "Republican": 737,
+          "total": 2510
+        },
+        "gun": {
+          "Democratic": 142,
+          "Republican": 7,
+          "total": 149
+        },
+        "immigra": {
+          "Democratic": 48,
+          "Republican": 1,
+          "total": 49
+        },
+        "rights": {
+          "Democratic": 164,
+          "Republican": 21,
+          "total": 185
+        }
+      }
     },
     {
-        "state": "DE",
-        "Democratic": 1414,
-        "Republican": 9,
-        "total": 1423
+      "state": "DE",
+      "Democratic": 1366,
+      "Republican": 8,
+      "total": 1374,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 44,
+          "Republican": 0,
+          "total": 44
+        },
+        "capitol": {
+          "Democratic": 61,
+          "Republican": 0,
+          "total": 61
+        },
+        "climate": {
+          "Democratic": 25,
+          "Republican": 0,
+          "total": 25
+        },
+        "covid": {
+          "Democratic": 997,
+          "Republican": 7,
+          "total": 1004
+        },
+        "gun": {
+          "Democratic": 116,
+          "Republican": 1,
+          "total": 117
+        },
+        "immigra": {
+          "Democratic": 17,
+          "Republican": 0,
+          "total": 17
+        },
+        "rights": {
+          "Democratic": 106,
+          "Republican": 0,
+          "total": 106
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 44,
+          "Republican": 0,
+          "total": 44
+        },
+        "capitol": {
+          "Democratic": 61,
+          "Republican": 0,
+          "total": 61
+        },
+        "climate": {
+          "Democratic": 25,
+          "Republican": 0,
+          "total": 25
+        },
+        "covid": {
+          "Democratic": 997,
+          "Republican": 7,
+          "total": 1004
+        },
+        "gun": {
+          "Democratic": 116,
+          "Republican": 1,
+          "total": 117
+        },
+        "immigra": {
+          "Democratic": 17,
+          "Republican": 0,
+          "total": 17
+        },
+        "rights": {
+          "Democratic": 106,
+          "Republican": 0,
+          "total": 106
+        }
+      }
     },
     {
-        "state": "FL",
-        "Democratic": 7661,
-        "Republican": 3241,
-        "total": 10902
+      "state": "FL",
+      "Democratic": 7407,
+      "Republican": 3164,
+      "total": 10571,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 160,
+          "Republican": 40,
+          "total": 200
+        },
+        "capitol": {
+          "Democratic": 137,
+          "Republican": 46,
+          "total": 183
+        },
+        "climate": {
+          "Democratic": 183,
+          "Republican": 101,
+          "total": 284
+        },
+        "covid": {
+          "Democratic": 5645,
+          "Republican": 2525,
+          "total": 8170
+        },
+        "gun": {
+          "Democratic": 493,
+          "Republican": 109,
+          "total": 602
+        },
+        "immigra": {
+          "Democratic": 124,
+          "Republican": 118,
+          "total": 242
+        },
+        "rights": {
+          "Democratic": 665,
+          "Republican": 225,
+          "total": 890
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 160,
+          "Republican": 40,
+          "total": 200
+        },
+        "capitol": {
+          "Democratic": 137,
+          "Republican": 46,
+          "total": 183
+        },
+        "climate": {
+          "Democratic": 183,
+          "Republican": 101,
+          "total": 284
+        },
+        "covid": {
+          "Democratic": 5645,
+          "Republican": 2525,
+          "total": 8170
+        },
+        "gun": {
+          "Democratic": 493,
+          "Republican": 109,
+          "total": 602
+        },
+        "immigra": {
+          "Democratic": 124,
+          "Republican": 118,
+          "total": 242
+        },
+        "rights": {
+          "Democratic": 665,
+          "Republican": 225,
+          "total": 890
+        }
+      }
     },
     {
-        "state": "GA",
-        "Democratic": 5747,
-        "Republican": 937,
-        "total": 6684
+      "state": "GA",
+      "Democratic": 5422,
+      "Republican": 915,
+      "total": 6337,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 181,
+          "Republican": 61,
+          "total": 242
+        },
+        "capitol": {
+          "Democratic": 212,
+          "Republican": 25,
+          "total": 237
+        },
+        "climate": {
+          "Democratic": 58,
+          "Republican": 13,
+          "total": 71
+        },
+        "covid": {
+          "Democratic": 3781,
+          "Republican": 694,
+          "total": 4475
+        },
+        "gun": {
+          "Democratic": 329,
+          "Republican": 23,
+          "total": 352
+        },
+        "immigra": {
+          "Democratic": 113,
+          "Republican": 22,
+          "total": 135
+        },
+        "rights": {
+          "Democratic": 748,
+          "Republican": 77,
+          "total": 825
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 181,
+          "Republican": 61,
+          "total": 242
+        },
+        "capitol": {
+          "Democratic": 212,
+          "Republican": 25,
+          "total": 237
+        },
+        "climate": {
+          "Democratic": 58,
+          "Republican": 13,
+          "total": 71
+        },
+        "covid": {
+          "Democratic": 3781,
+          "Republican": 694,
+          "total": 4475
+        },
+        "gun": {
+          "Democratic": 329,
+          "Republican": 23,
+          "total": 352
+        },
+        "immigra": {
+          "Democratic": 113,
+          "Republican": 22,
+          "total": 135
+        },
+        "rights": {
+          "Democratic": 748,
+          "Republican": 77,
+          "total": 825
+        }
+      }
     },
     {
-        "state": "HI",
-        "Democratic": 1038,
-        "Republican": 127,
-        "total": 1165
+      "state": "HI",
+      "Democratic": 1027,
+      "Republican": 126,
+      "total": 1153,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 2,
+          "Republican": 1,
+          "total": 3
+        },
+        "capitol": {
+          "Democratic": 28,
+          "Republican": 0,
+          "total": 28
+        },
+        "climate": {
+          "Democratic": 42,
+          "Republican": 0,
+          "total": 42
+        },
+        "covid": {
+          "Democratic": 897,
+          "Republican": 122,
+          "total": 1019
+        },
+        "gun": {
+          "Democratic": 19,
+          "Republican": 1,
+          "total": 20
+        },
+        "immigra": {
+          "Democratic": 7,
+          "Republican": 0,
+          "total": 7
+        },
+        "rights": {
+          "Democratic": 32,
+          "Republican": 2,
+          "total": 34
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 2,
+          "Republican": 1,
+          "total": 3
+        },
+        "capitol": {
+          "Democratic": 28,
+          "Republican": 0,
+          "total": 28
+        },
+        "climate": {
+          "Democratic": 42,
+          "Republican": 0,
+          "total": 42
+        },
+        "covid": {
+          "Democratic": 897,
+          "Republican": 122,
+          "total": 1019
+        },
+        "gun": {
+          "Democratic": 19,
+          "Republican": 1,
+          "total": 20
+        },
+        "immigra": {
+          "Democratic": 7,
+          "Republican": 0,
+          "total": 7
+        },
+        "rights": {
+          "Democratic": 32,
+          "Republican": 2,
+          "total": 34
+        }
+      }
     },
     {
-        "state": "IA",
-        "Democratic": 4814,
-        "Republican": 334,
-        "total": 5148
+      "state": "IA",
+      "Democratic": 4735,
+      "Republican": 330,
+      "total": 5065,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 63,
+          "Republican": 14,
+          "total": 77
+        },
+        "capitol": {
+          "Democratic": 106,
+          "Republican": 2,
+          "total": 108
+        },
+        "climate": {
+          "Democratic": 467,
+          "Republican": 8,
+          "total": 475
+        },
+        "covid": {
+          "Democratic": 3649,
+          "Republican": 248,
+          "total": 3897
+        },
+        "gun": {
+          "Democratic": 124,
+          "Republican": 14,
+          "total": 138
+        },
+        "immigra": {
+          "Democratic": 24,
+          "Republican": 17,
+          "total": 41
+        },
+        "rights": {
+          "Democratic": 302,
+          "Republican": 27,
+          "total": 329
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 63,
+          "Republican": 14,
+          "total": 77
+        },
+        "capitol": {
+          "Democratic": 106,
+          "Republican": 2,
+          "total": 108
+        },
+        "climate": {
+          "Democratic": 467,
+          "Republican": 8,
+          "total": 475
+        },
+        "covid": {
+          "Democratic": 3649,
+          "Republican": 248,
+          "total": 3897
+        },
+        "gun": {
+          "Democratic": 124,
+          "Republican": 14,
+          "total": 138
+        },
+        "immigra": {
+          "Democratic": 24,
+          "Republican": 17,
+          "total": 41
+        },
+        "rights": {
+          "Democratic": 302,
+          "Republican": 27,
+          "total": 329
+        }
+      }
     },
     {
-        "state": "ID",
-        "Democratic": 488,
-        "Republican": 174,
-        "total": 662
+      "state": "ID",
+      "Democratic": 473,
+      "Republican": 171,
+      "total": 644,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 10,
+          "Republican": 1,
+          "total": 11
+        },
+        "capitol": {
+          "Democratic": 44,
+          "Republican": 7,
+          "total": 51
+        },
+        "climate": {
+          "Democratic": 20,
+          "Republican": 3,
+          "total": 23
+        },
+        "covid": {
+          "Democratic": 299,
+          "Republican": 136,
+          "total": 435
+        },
+        "gun": {
+          "Democratic": 44,
+          "Republican": 7,
+          "total": 51
+        },
+        "immigra": {
+          "Democratic": 6,
+          "Republican": 2,
+          "total": 8
+        },
+        "rights": {
+          "Democratic": 50,
+          "Republican": 15,
+          "total": 65
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 10,
+          "Republican": 1,
+          "total": 11
+        },
+        "capitol": {
+          "Democratic": 44,
+          "Republican": 7,
+          "total": 51
+        },
+        "climate": {
+          "Democratic": 20,
+          "Republican": 3,
+          "total": 23
+        },
+        "covid": {
+          "Democratic": 299,
+          "Republican": 136,
+          "total": 435
+        },
+        "gun": {
+          "Democratic": 44,
+          "Republican": 7,
+          "total": 51
+        },
+        "immigra": {
+          "Democratic": 6,
+          "Republican": 2,
+          "total": 8
+        },
+        "rights": {
+          "Democratic": 50,
+          "Republican": 15,
+          "total": 65
+        }
+      }
     },
     {
-        "state": "IL",
-        "Democratic": 3110,
-        "Republican": 626,
-        "total": 3736
+      "state": "IL",
+      "Democratic": 2979,
+      "Republican": 608,
+      "total": 3587,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 34,
+          "Republican": 31,
+          "total": 65
+        },
+        "capitol": {
+          "Democratic": 19,
+          "Republican": 19,
+          "total": 38
+        },
+        "climate": {
+          "Democratic": 234,
+          "Republican": 13,
+          "total": 247
+        },
+        "covid": {
+          "Democratic": 2356,
+          "Republican": 464,
+          "total": 2820
+        },
+        "gun": {
+          "Democratic": 87,
+          "Republican": 25,
+          "total": 112
+        },
+        "immigra": {
+          "Democratic": 62,
+          "Republican": 14,
+          "total": 76
+        },
+        "rights": {
+          "Democratic": 187,
+          "Republican": 42,
+          "total": 229
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 34,
+          "Republican": 31,
+          "total": 65
+        },
+        "capitol": {
+          "Democratic": 19,
+          "Republican": 19,
+          "total": 38
+        },
+        "climate": {
+          "Democratic": 234,
+          "Republican": 13,
+          "total": 247
+        },
+        "covid": {
+          "Democratic": 2356,
+          "Republican": 464,
+          "total": 2820
+        },
+        "gun": {
+          "Democratic": 87,
+          "Republican": 25,
+          "total": 112
+        },
+        "immigra": {
+          "Democratic": 62,
+          "Republican": 14,
+          "total": 76
+        },
+        "rights": {
+          "Democratic": 187,
+          "Republican": 42,
+          "total": 229
+        }
+      }
     },
     {
-        "state": "IN",
-        "Democratic": 651,
-        "Republican": 1053,
-        "total": 1704
+      "state": "IN",
+      "Democratic": 627,
+      "Republican": 1020,
+      "total": 1647,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 3,
+          "Republican": 103,
+          "total": 106
+        },
+        "capitol": {
+          "Democratic": 1,
+          "Republican": 19,
+          "total": 20
+        },
+        "climate": {
+          "Democratic": 37,
+          "Republican": 21,
+          "total": 58
+        },
+        "covid": {
+          "Democratic": 507,
+          "Republican": 756,
+          "total": 1263
+        },
+        "gun": {
+          "Democratic": 28,
+          "Republican": 33,
+          "total": 61
+        },
+        "immigra": {
+          "Democratic": 3,
+          "Republican": 41,
+          "total": 44
+        },
+        "rights": {
+          "Democratic": 48,
+          "Republican": 47,
+          "total": 95
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 3,
+          "Republican": 103,
+          "total": 106
+        },
+        "capitol": {
+          "Democratic": 1,
+          "Republican": 19,
+          "total": 20
+        },
+        "climate": {
+          "Democratic": 37,
+          "Republican": 21,
+          "total": 58
+        },
+        "covid": {
+          "Democratic": 507,
+          "Republican": 756,
+          "total": 1263
+        },
+        "gun": {
+          "Democratic": 28,
+          "Republican": 33,
+          "total": 61
+        },
+        "immigra": {
+          "Democratic": 3,
+          "Republican": 41,
+          "total": 44
+        },
+        "rights": {
+          "Democratic": 48,
+          "Republican": 47,
+          "total": 95
+        }
+      }
     },
     {
-        "state": "KS",
-        "Democratic": 1225,
-        "Republican": 523,
-        "total": 1748
+      "state": "KS",
+      "Democratic": 1189,
+      "Republican": 516,
+      "total": 1705,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 134,
+          "Republican": 24,
+          "total": 158
+        },
+        "capitol": {
+          "Democratic": 26,
+          "Republican": 1,
+          "total": 27
+        },
+        "climate": {
+          "Democratic": 24,
+          "Republican": 6,
+          "total": 30
+        },
+        "covid": {
+          "Democratic": 773,
+          "Republican": 440,
+          "total": 1213
+        },
+        "gun": {
+          "Democratic": 81,
+          "Republican": 11,
+          "total": 92
+        },
+        "immigra": {
+          "Democratic": 11,
+          "Republican": 2,
+          "total": 13
+        },
+        "rights": {
+          "Democratic": 140,
+          "Republican": 32,
+          "total": 172
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 134,
+          "Republican": 24,
+          "total": 158
+        },
+        "capitol": {
+          "Democratic": 26,
+          "Republican": 1,
+          "total": 27
+        },
+        "climate": {
+          "Democratic": 24,
+          "Republican": 6,
+          "total": 30
+        },
+        "covid": {
+          "Democratic": 773,
+          "Republican": 440,
+          "total": 1213
+        },
+        "gun": {
+          "Democratic": 81,
+          "Republican": 11,
+          "total": 92
+        },
+        "immigra": {
+          "Democratic": 11,
+          "Republican": 2,
+          "total": 13
+        },
+        "rights": {
+          "Democratic": 140,
+          "Republican": 32,
+          "total": 172
+        }
+      }
     },
     {
-        "state": "KY",
-        "Democratic": 1770,
-        "Republican": 1095,
-        "total": 2865
+      "state": "KY",
+      "Democratic": 1643,
+      "Republican": 1025,
+      "total": 2668,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 92,
+          "Republican": 93,
+          "total": 185
+        },
+        "capitol": {
+          "Democratic": 89,
+          "Republican": 65,
+          "total": 154
+        },
+        "climate": {
+          "Democratic": 97,
+          "Republican": 5,
+          "total": 102
+        },
+        "covid": {
+          "Democratic": 1006,
+          "Republican": 675,
+          "total": 1681
+        },
+        "gun": {
+          "Democratic": 121,
+          "Republican": 37,
+          "total": 158
+        },
+        "immigra": {
+          "Democratic": 44,
+          "Republican": 13,
+          "total": 57
+        },
+        "rights": {
+          "Democratic": 194,
+          "Republican": 137,
+          "total": 331
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 92,
+          "Republican": 93,
+          "total": 185
+        },
+        "capitol": {
+          "Democratic": 89,
+          "Republican": 65,
+          "total": 154
+        },
+        "climate": {
+          "Democratic": 97,
+          "Republican": 5,
+          "total": 102
+        },
+        "covid": {
+          "Democratic": 1006,
+          "Republican": 675,
+          "total": 1681
+        },
+        "gun": {
+          "Democratic": 121,
+          "Republican": 37,
+          "total": 158
+        },
+        "immigra": {
+          "Democratic": 44,
+          "Republican": 13,
+          "total": 57
+        },
+        "rights": {
+          "Democratic": 194,
+          "Republican": 137,
+          "total": 331
+        }
+      }
     },
     {
-        "state": "LA",
-        "Democratic": 1076,
-        "Republican": 344,
-        "total": 1420
+      "state": "LA",
+      "Democratic": 1023,
+      "Republican": 342,
+      "total": 1365,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 26,
+          "Republican": 19,
+          "total": 45
+        },
+        "capitol": {
+          "Democratic": 12,
+          "Republican": 2,
+          "total": 14
+        },
+        "climate": {
+          "Democratic": 40,
+          "Republican": 19,
+          "total": 59
+        },
+        "covid": {
+          "Democratic": 777,
+          "Republican": 240,
+          "total": 1017
+        },
+        "gun": {
+          "Democratic": 47,
+          "Republican": 24,
+          "total": 71
+        },
+        "immigra": {
+          "Democratic": 10,
+          "Republican": 9,
+          "total": 19
+        },
+        "rights": {
+          "Democratic": 111,
+          "Republican": 29,
+          "total": 140
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 26,
+          "Republican": 19,
+          "total": 45
+        },
+        "capitol": {
+          "Democratic": 12,
+          "Republican": 2,
+          "total": 14
+        },
+        "climate": {
+          "Democratic": 40,
+          "Republican": 19,
+          "total": 59
+        },
+        "covid": {
+          "Democratic": 777,
+          "Republican": 240,
+          "total": 1017
+        },
+        "gun": {
+          "Democratic": 47,
+          "Republican": 24,
+          "total": 71
+        },
+        "immigra": {
+          "Democratic": 10,
+          "Republican": 9,
+          "total": 19
+        },
+        "rights": {
+          "Democratic": 111,
+          "Republican": 29,
+          "total": 140
+        }
+      }
     },
     {
-        "state": "MA",
-        "Democratic": 15570,
-        "Republican": 2075,
-        "total": 17645
+      "state": "MA",
+      "Democratic": 15003,
+      "Republican": 2019,
+      "total": 17022,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 290,
+          "Republican": 2,
+          "total": 292
+        },
+        "capitol": {
+          "Democratic": 49,
+          "Republican": 2,
+          "total": 51
+        },
+        "climate": {
+          "Democratic": 1913,
+          "Republican": 41,
+          "total": 1954
+        },
+        "covid": {
+          "Democratic": 11023,
+          "Republican": 1919,
+          "total": 12942
+        },
+        "gun": {
+          "Democratic": 322,
+          "Republican": 11,
+          "total": 333
+        },
+        "immigra": {
+          "Democratic": 574,
+          "Republican": 8,
+          "total": 582
+        },
+        "rights": {
+          "Democratic": 832,
+          "Republican": 36,
+          "total": 868
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 290,
+          "Republican": 2,
+          "total": 292
+        },
+        "capitol": {
+          "Democratic": 49,
+          "Republican": 2,
+          "total": 51
+        },
+        "climate": {
+          "Democratic": 1913,
+          "Republican": 41,
+          "total": 1954
+        },
+        "covid": {
+          "Democratic": 11023,
+          "Republican": 1919,
+          "total": 12942
+        },
+        "gun": {
+          "Democratic": 322,
+          "Republican": 11,
+          "total": 333
+        },
+        "immigra": {
+          "Democratic": 574,
+          "Republican": 8,
+          "total": 582
+        },
+        "rights": {
+          "Democratic": 832,
+          "Republican": 36,
+          "total": 868
+        }
+      }
     },
     {
-        "state": "MD",
-        "Democratic": 9135,
-        "Republican": 892,
-        "total": 10027
+      "state": "MD",
+      "Democratic": 8291,
+      "Republican": 855,
+      "total": 9146,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 74,
+          "Republican": 19,
+          "total": 93
+        },
+        "capitol": {
+          "Democratic": 120,
+          "Republican": 16,
+          "total": 136
+        },
+        "climate": {
+          "Democratic": 426,
+          "Republican": 16,
+          "total": 442
+        },
+        "covid": {
+          "Democratic": 6038,
+          "Republican": 569,
+          "total": 6607
+        },
+        "gun": {
+          "Democratic": 452,
+          "Republican": 134,
+          "total": 586
+        },
+        "immigra": {
+          "Democratic": 422,
+          "Republican": 23,
+          "total": 445
+        },
+        "rights": {
+          "Democratic": 759,
+          "Republican": 78,
+          "total": 837
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 74,
+          "Republican": 19,
+          "total": 93
+        },
+        "capitol": {
+          "Democratic": 120,
+          "Republican": 16,
+          "total": 136
+        },
+        "climate": {
+          "Democratic": 426,
+          "Republican": 16,
+          "total": 442
+        },
+        "covid": {
+          "Democratic": 6038,
+          "Republican": 569,
+          "total": 6607
+        },
+        "gun": {
+          "Democratic": 452,
+          "Republican": 134,
+          "total": 586
+        },
+        "immigra": {
+          "Democratic": 422,
+          "Republican": 23,
+          "total": 445
+        },
+        "rights": {
+          "Democratic": 759,
+          "Republican": 78,
+          "total": 837
+        }
+      }
     },
     {
-        "state": "ME",
-        "Democratic": 1523,
-        "Republican": 31,
-        "total": 1554
+      "state": "ME",
+      "Democratic": 1470,
+      "Republican": 30,
+      "total": 1500,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 25,
+          "Republican": 0,
+          "total": 25
+        },
+        "capitol": {
+          "Democratic": 34,
+          "Republican": 4,
+          "total": 38
+        },
+        "climate": {
+          "Democratic": 210,
+          "Republican": 2,
+          "total": 212
+        },
+        "covid": {
+          "Democratic": 910,
+          "Republican": 16,
+          "total": 926
+        },
+        "gun": {
+          "Democratic": 59,
+          "Republican": 3,
+          "total": 62
+        },
+        "immigra": {
+          "Democratic": 20,
+          "Republican": 0,
+          "total": 20
+        },
+        "rights": {
+          "Democratic": 212,
+          "Republican": 5,
+          "total": 217
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 25,
+          "Republican": 0,
+          "total": 25
+        },
+        "capitol": {
+          "Democratic": 34,
+          "Republican": 4,
+          "total": 38
+        },
+        "climate": {
+          "Democratic": 210,
+          "Republican": 2,
+          "total": 212
+        },
+        "covid": {
+          "Democratic": 910,
+          "Republican": 16,
+          "total": 926
+        },
+        "gun": {
+          "Democratic": 59,
+          "Republican": 3,
+          "total": 62
+        },
+        "immigra": {
+          "Democratic": 20,
+          "Republican": 0,
+          "total": 20
+        },
+        "rights": {
+          "Democratic": 212,
+          "Republican": 5,
+          "total": 217
+        }
+      }
     },
     {
-        "state": "MI",
-        "Democratic": 4769,
-        "Republican": 600,
-        "total": 5369
+      "state": "MI",
+      "Democratic": 4565,
+      "Republican": 593,
+      "total": 5158,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 94,
+          "Republican": 7,
+          "total": 101
+        },
+        "capitol": {
+          "Democratic": 163,
+          "Republican": 11,
+          "total": 174
+        },
+        "climate": {
+          "Democratic": 209,
+          "Republican": 22,
+          "total": 231
+        },
+        "covid": {
+          "Democratic": 3174,
+          "Republican": 472,
+          "total": 3646
+        },
+        "gun": {
+          "Democratic": 341,
+          "Republican": 33,
+          "total": 374
+        },
+        "immigra": {
+          "Democratic": 89,
+          "Republican": 6,
+          "total": 95
+        },
+        "rights": {
+          "Democratic": 495,
+          "Republican": 42,
+          "total": 537
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 94,
+          "Republican": 7,
+          "total": 101
+        },
+        "capitol": {
+          "Democratic": 163,
+          "Republican": 11,
+          "total": 174
+        },
+        "climate": {
+          "Democratic": 209,
+          "Republican": 22,
+          "total": 231
+        },
+        "covid": {
+          "Democratic": 3174,
+          "Republican": 472,
+          "total": 3646
+        },
+        "gun": {
+          "Democratic": 341,
+          "Republican": 33,
+          "total": 374
+        },
+        "immigra": {
+          "Democratic": 89,
+          "Republican": 6,
+          "total": 95
+        },
+        "rights": {
+          "Democratic": 495,
+          "Republican": 42,
+          "total": 537
+        }
+      }
     },
     {
-        "state": "MN",
-        "Democratic": 11895,
-        "Republican": 1791,
-        "total": 13686
+      "state": "MN",
+      "Democratic": 10738,
+      "Republican": 1744,
+      "total": 12482,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 198,
+          "Republican": 27,
+          "total": 225
+        },
+        "capitol": {
+          "Democratic": 322,
+          "Republican": 43,
+          "total": 365
+        },
+        "climate": {
+          "Democratic": 1292,
+          "Republican": 41,
+          "total": 1333
+        },
+        "covid": {
+          "Democratic": 7292,
+          "Republican": 1417,
+          "total": 8709
+        },
+        "gun": {
+          "Democratic": 516,
+          "Republican": 84,
+          "total": 600
+        },
+        "immigra": {
+          "Democratic": 327,
+          "Republican": 23,
+          "total": 350
+        },
+        "rights": {
+          "Democratic": 791,
+          "Republican": 109,
+          "total": 900
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 198,
+          "Republican": 27,
+          "total": 225
+        },
+        "capitol": {
+          "Democratic": 322,
+          "Republican": 43,
+          "total": 365
+        },
+        "climate": {
+          "Democratic": 1292,
+          "Republican": 41,
+          "total": 1333
+        },
+        "covid": {
+          "Democratic": 7292,
+          "Republican": 1417,
+          "total": 8709
+        },
+        "gun": {
+          "Democratic": 516,
+          "Republican": 84,
+          "total": 600
+        },
+        "immigra": {
+          "Democratic": 327,
+          "Republican": 23,
+          "total": 350
+        },
+        "rights": {
+          "Democratic": 791,
+          "Republican": 109,
+          "total": 900
+        }
+      }
     },
     {
-        "state": "MO",
-        "Democratic": 4248,
-        "Republican": 2529,
-        "total": 6777
+      "state": "MO",
+      "Democratic": 4076,
+      "Republican": 2451,
+      "total": 6527,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 145,
+          "Republican": 273,
+          "total": 418
+        },
+        "capitol": {
+          "Democratic": 81,
+          "Republican": 26,
+          "total": 107
+        },
+        "climate": {
+          "Democratic": 40,
+          "Republican": 29,
+          "total": 69
+        },
+        "covid": {
+          "Democratic": 2994,
+          "Republican": 1456,
+          "total": 4450
+        },
+        "gun": {
+          "Democratic": 465,
+          "Republican": 260,
+          "total": 725
+        },
+        "immigra": {
+          "Democratic": 52,
+          "Republican": 40,
+          "total": 92
+        },
+        "rights": {
+          "Democratic": 299,
+          "Republican": 367,
+          "total": 666
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 145,
+          "Republican": 273,
+          "total": 418
+        },
+        "capitol": {
+          "Democratic": 81,
+          "Republican": 26,
+          "total": 107
+        },
+        "climate": {
+          "Democratic": 40,
+          "Republican": 29,
+          "total": 69
+        },
+        "covid": {
+          "Democratic": 2994,
+          "Republican": 1456,
+          "total": 4450
+        },
+        "gun": {
+          "Democratic": 465,
+          "Republican": 260,
+          "total": 725
+        },
+        "immigra": {
+          "Democratic": 52,
+          "Republican": 40,
+          "total": 92
+        },
+        "rights": {
+          "Democratic": 299,
+          "Republican": 367,
+          "total": 666
+        }
+      }
     },
     {
-        "state": "MS",
-        "Democratic": 429,
-        "Republican": 428,
-        "total": 857
+      "state": "MS",
+      "Democratic": 413,
+      "Republican": 415,
+      "total": 828,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 2,
+          "Republican": 7,
+          "total": 9
+        },
+        "capitol": {
+          "Democratic": 13,
+          "Republican": 12,
+          "total": 25
+        },
+        "covid": {
+          "Democratic": 339,
+          "Republican": 334,
+          "total": 673
+        },
+        "gun": {
+          "Democratic": 13,
+          "Republican": 33,
+          "total": 46
+        },
+        "immigra": {
+          "Democratic": 5,
+          "Republican": 3,
+          "total": 8
+        },
+        "rights": {
+          "Democratic": 41,
+          "Republican": 25,
+          "total": 66
+        },
+        "climate": {
+          "Democratic": 0,
+          "Republican": 1,
+          "total": 1
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 2,
+          "Republican": 7,
+          "total": 9
+        },
+        "capitol": {
+          "Democratic": 13,
+          "Republican": 12,
+          "total": 25
+        },
+        "covid": {
+          "Democratic": 339,
+          "Republican": 334,
+          "total": 673
+        },
+        "gun": {
+          "Democratic": 13,
+          "Republican": 33,
+          "total": 46
+        },
+        "immigra": {
+          "Democratic": 5,
+          "Republican": 3,
+          "total": 8
+        },
+        "rights": {
+          "Democratic": 41,
+          "Republican": 25,
+          "total": 66
+        },
+        "climate": {
+          "Democratic": 0,
+          "Republican": 1,
+          "total": 1
+        }
+      }
     },
     {
-        "state": "MT",
-        "Democratic": 1103,
-        "Republican": 140,
-        "total": 1243
+      "state": "MT",
+      "Democratic": 1075,
+      "Republican": 139,
+      "total": 1214,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 63,
+          "Republican": 1,
+          "total": 64
+        },
+        "capitol": {
+          "Democratic": 72,
+          "Republican": 7,
+          "total": 79
+        },
+        "climate": {
+          "Democratic": 101,
+          "Republican": 7,
+          "total": 108
+        },
+        "covid": {
+          "Democratic": 624,
+          "Republican": 87,
+          "total": 711
+        },
+        "gun": {
+          "Democratic": 75,
+          "Republican": 18,
+          "total": 93
+        },
+        "immigra": {
+          "Democratic": 11,
+          "Republican": 1,
+          "total": 12
+        },
+        "rights": {
+          "Democratic": 129,
+          "Republican": 18,
+          "total": 147
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 63,
+          "Republican": 1,
+          "total": 64
+        },
+        "capitol": {
+          "Democratic": 72,
+          "Republican": 7,
+          "total": 79
+        },
+        "climate": {
+          "Democratic": 101,
+          "Republican": 7,
+          "total": 108
+        },
+        "covid": {
+          "Democratic": 624,
+          "Republican": 87,
+          "total": 711
+        },
+        "gun": {
+          "Democratic": 75,
+          "Republican": 18,
+          "total": 93
+        },
+        "immigra": {
+          "Democratic": 11,
+          "Republican": 1,
+          "total": 12
+        },
+        "rights": {
+          "Democratic": 129,
+          "Republican": 18,
+          "total": 147
+        }
+      }
     },
     {
-        "state": "NC",
-        "Democratic": 5873,
-        "Republican": 1167,
-        "total": 7040
+      "state": "NC",
+      "Democratic": 5672,
+      "Republican": 1150,
+      "total": 6822,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 89,
+          "Republican": 8,
+          "total": 97
+        },
+        "capitol": {
+          "Democratic": 206,
+          "Republican": 11,
+          "total": 217
+        },
+        "climate": {
+          "Democratic": 239,
+          "Republican": 50,
+          "total": 289
+        },
+        "covid": {
+          "Democratic": 4025,
+          "Republican": 991,
+          "total": 5016
+        },
+        "gun": {
+          "Democratic": 510,
+          "Republican": 25,
+          "total": 535
+        },
+        "immigra": {
+          "Democratic": 91,
+          "Republican": 9,
+          "total": 100
+        },
+        "rights": {
+          "Democratic": 512,
+          "Republican": 56,
+          "total": 568
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 89,
+          "Republican": 8,
+          "total": 97
+        },
+        "capitol": {
+          "Democratic": 206,
+          "Republican": 11,
+          "total": 217
+        },
+        "climate": {
+          "Democratic": 239,
+          "Republican": 50,
+          "total": 289
+        },
+        "covid": {
+          "Democratic": 4025,
+          "Republican": 991,
+          "total": 5016
+        },
+        "gun": {
+          "Democratic": 510,
+          "Republican": 25,
+          "total": 535
+        },
+        "immigra": {
+          "Democratic": 91,
+          "Republican": 9,
+          "total": 100
+        },
+        "rights": {
+          "Democratic": 512,
+          "Republican": 56,
+          "total": 568
+        }
+      }
     },
     {
-        "state": "ND",
-        "Democratic": 873,
-        "Republican": 110,
-        "total": 983
+      "state": "ND",
+      "Democratic": 852,
+      "Republican": 100,
+      "total": 952,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 16,
+          "Republican": 6,
+          "total": 22
+        },
+        "capitol": {
+          "Democratic": 2,
+          "Republican": 5,
+          "total": 7
+        },
+        "climate": {
+          "Democratic": 6,
+          "Republican": 1,
+          "total": 7
+        },
+        "covid": {
+          "Democratic": 752,
+          "Republican": 78,
+          "total": 830
+        },
+        "gun": {
+          "Democratic": 40,
+          "Republican": 6,
+          "total": 46
+        },
+        "immigra": {
+          "Democratic": 3,
+          "Republican": 0,
+          "total": 3
+        },
+        "rights": {
+          "Democratic": 33,
+          "Republican": 4,
+          "total": 37
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 16,
+          "Republican": 6,
+          "total": 22
+        },
+        "capitol": {
+          "Democratic": 2,
+          "Republican": 5,
+          "total": 7
+        },
+        "climate": {
+          "Democratic": 6,
+          "Republican": 1,
+          "total": 7
+        },
+        "covid": {
+          "Democratic": 752,
+          "Republican": 78,
+          "total": 830
+        },
+        "gun": {
+          "Democratic": 40,
+          "Republican": 6,
+          "total": 46
+        },
+        "immigra": {
+          "Democratic": 3,
+          "Republican": 0,
+          "total": 3
+        },
+        "rights": {
+          "Democratic": 33,
+          "Republican": 4,
+          "total": 37
+        }
+      }
     },
     {
-        "state": "NE",
-        "Democratic": 1331,
-        "Republican": 11,
-        "total": 1342
+      "state": "NE",
+      "Democratic": 1295,
+      "Republican": 11,
+      "total": 1306,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 6,
+          "Republican": 0,
+          "total": 6
+        },
+        "capitol": {
+          "Democratic": 24,
+          "Republican": 0,
+          "total": 24
+        },
+        "climate": {
+          "Democratic": 22,
+          "Republican": 0,
+          "total": 22
+        },
+        "covid": {
+          "Democratic": 1070,
+          "Republican": 11,
+          "total": 1081
+        },
+        "gun": {
+          "Democratic": 28,
+          "Republican": 0,
+          "total": 28
+        },
+        "immigra": {
+          "Democratic": 37,
+          "Republican": 0,
+          "total": 37
+        },
+        "rights": {
+          "Democratic": 108,
+          "Republican": 0,
+          "total": 108
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 6,
+          "Republican": 0,
+          "total": 6
+        },
+        "capitol": {
+          "Democratic": 24,
+          "Republican": 0,
+          "total": 24
+        },
+        "climate": {
+          "Democratic": 22,
+          "Republican": 0,
+          "total": 22
+        },
+        "covid": {
+          "Democratic": 1070,
+          "Republican": 11,
+          "total": 1081
+        },
+        "gun": {
+          "Democratic": 28,
+          "Republican": 0,
+          "total": 28
+        },
+        "immigra": {
+          "Democratic": 37,
+          "Republican": 0,
+          "total": 37
+        },
+        "rights": {
+          "Democratic": 108,
+          "Republican": 0,
+          "total": 108
+        }
+      }
     },
     {
-        "state": "NH",
-        "Democratic": 11869,
-        "Republican": 1268,
-        "total": 13137
+      "state": "NH",
+      "Democratic": 11414,
+      "Republican": 1213,
+      "total": 12627,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 654,
+          "Republican": 210,
+          "total": 864
+        },
+        "capitol": {
+          "Democratic": 609,
+          "Republican": 33,
+          "total": 642
+        },
+        "climate": {
+          "Democratic": 784,
+          "Republican": 39,
+          "total": 823
+        },
+        "covid": {
+          "Democratic": 7133,
+          "Republican": 586,
+          "total": 7719
+        },
+        "gun": {
+          "Democratic": 745,
+          "Republican": 164,
+          "total": 909
+        },
+        "immigra": {
+          "Democratic": 302,
+          "Republican": 66,
+          "total": 368
+        },
+        "rights": {
+          "Democratic": 1187,
+          "Republican": 115,
+          "total": 1302
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 654,
+          "Republican": 210,
+          "total": 864
+        },
+        "capitol": {
+          "Democratic": 609,
+          "Republican": 33,
+          "total": 642
+        },
+        "climate": {
+          "Democratic": 784,
+          "Republican": 39,
+          "total": 823
+        },
+        "covid": {
+          "Democratic": 7133,
+          "Republican": 586,
+          "total": 7719
+        },
+        "gun": {
+          "Democratic": 745,
+          "Republican": 164,
+          "total": 909
+        },
+        "immigra": {
+          "Democratic": 302,
+          "Republican": 66,
+          "total": 368
+        },
+        "rights": {
+          "Democratic": 1187,
+          "Republican": 115,
+          "total": 1302
+        }
+      }
     },
     {
-        "state": "NJ",
-        "Democratic": 1983,
-        "Republican": 770,
-        "total": 2753
+      "state": "NJ",
+      "Democratic": 1890,
+      "Republican": 759,
+      "total": 2649,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 10,
+          "Republican": 1,
+          "total": 11
+        },
+        "capitol": {
+          "Democratic": 11,
+          "Republican": 1,
+          "total": 12
+        },
+        "climate": {
+          "Democratic": 44,
+          "Republican": 5,
+          "total": 49
+        },
+        "covid": {
+          "Democratic": 1520,
+          "Republican": 675,
+          "total": 2195
+        },
+        "gun": {
+          "Democratic": 64,
+          "Republican": 18,
+          "total": 82
+        },
+        "immigra": {
+          "Democratic": 48,
+          "Republican": 13,
+          "total": 61
+        },
+        "rights": {
+          "Democratic": 193,
+          "Republican": 46,
+          "total": 239
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 10,
+          "Republican": 1,
+          "total": 11
+        },
+        "capitol": {
+          "Democratic": 11,
+          "Republican": 1,
+          "total": 12
+        },
+        "climate": {
+          "Democratic": 44,
+          "Republican": 5,
+          "total": 49
+        },
+        "covid": {
+          "Democratic": 1520,
+          "Republican": 675,
+          "total": 2195
+        },
+        "gun": {
+          "Democratic": 64,
+          "Republican": 18,
+          "total": 82
+        },
+        "immigra": {
+          "Democratic": 48,
+          "Republican": 13,
+          "total": 61
+        },
+        "rights": {
+          "Democratic": 193,
+          "Republican": 46,
+          "total": 239
+        }
+      }
     },
     {
-        "state": "NM",
-        "Democratic": 8025,
-        "Republican": 145,
-        "total": 8170
+      "state": "NM",
+      "Democratic": 7745,
+      "Republican": 145,
+      "total": 7890,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 251,
+          "Republican": 11,
+          "total": 262
+        },
+        "capitol": {
+          "Democratic": 577,
+          "Republican": 1,
+          "total": 578
+        },
+        "climate": {
+          "Democratic": 489,
+          "Republican": 0,
+          "total": 489
+        },
+        "covid": {
+          "Democratic": 4982,
+          "Republican": 74,
+          "total": 5056
+        },
+        "gun": {
+          "Democratic": 572,
+          "Republican": 32,
+          "total": 604
+        },
+        "immigra": {
+          "Democratic": 255,
+          "Republican": 1,
+          "total": 256
+        },
+        "rights": {
+          "Democratic": 619,
+          "Republican": 26,
+          "total": 645
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 251,
+          "Republican": 11,
+          "total": 262
+        },
+        "capitol": {
+          "Democratic": 577,
+          "Republican": 1,
+          "total": 578
+        },
+        "climate": {
+          "Democratic": 489,
+          "Republican": 0,
+          "total": 489
+        },
+        "covid": {
+          "Democratic": 4982,
+          "Republican": 74,
+          "total": 5056
+        },
+        "gun": {
+          "Democratic": 572,
+          "Republican": 32,
+          "total": 604
+        },
+        "immigra": {
+          "Democratic": 255,
+          "Republican": 1,
+          "total": 256
+        },
+        "rights": {
+          "Democratic": 619,
+          "Republican": 26,
+          "total": 645
+        }
+      }
     },
     {
-        "state": "NV",
-        "Democratic": 2050,
-        "Republican": 348,
-        "total": 2398
+      "state": "NV",
+      "Democratic": 1968,
+      "Republican": 334,
+      "total": 2302,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 41,
+          "Republican": 2,
+          "total": 43
+        },
+        "capitol": {
+          "Democratic": 137,
+          "Republican": 6,
+          "total": 143
+        },
+        "climate": {
+          "Democratic": 95,
+          "Republican": 4,
+          "total": 99
+        },
+        "covid": {
+          "Democratic": 1178,
+          "Republican": 250,
+          "total": 1428
+        },
+        "gun": {
+          "Democratic": 84,
+          "Republican": 31,
+          "total": 115
+        },
+        "immigra": {
+          "Democratic": 147,
+          "Republican": 2,
+          "total": 149
+        },
+        "rights": {
+          "Democratic": 286,
+          "Republican": 39,
+          "total": 325
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 41,
+          "Republican": 2,
+          "total": 43
+        },
+        "capitol": {
+          "Democratic": 137,
+          "Republican": 6,
+          "total": 143
+        },
+        "climate": {
+          "Democratic": 95,
+          "Republican": 4,
+          "total": 99
+        },
+        "covid": {
+          "Democratic": 1178,
+          "Republican": 250,
+          "total": 1428
+        },
+        "gun": {
+          "Democratic": 84,
+          "Republican": 31,
+          "total": 115
+        },
+        "immigra": {
+          "Democratic": 147,
+          "Republican": 2,
+          "total": 149
+        },
+        "rights": {
+          "Democratic": 286,
+          "Republican": 39,
+          "total": 325
+        }
+      }
     },
     {
-        "state": "NY",
-        "Democratic": 17124,
-        "Republican": 2544,
-        "total": 19668
+      "state": "NY",
+      "Democratic": 16376,
+      "Republican": 2492,
+      "total": 18868,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 239,
+          "Republican": 8,
+          "total": 247
+        },
+        "capitol": {
+          "Democratic": 170,
+          "Republican": 31,
+          "total": 201
+        },
+        "climate": {
+          "Democratic": 926,
+          "Republican": 76,
+          "total": 1002
+        },
+        "covid": {
+          "Democratic": 11297,
+          "Republican": 2045,
+          "total": 13342
+        },
+        "gun": {
+          "Democratic": 834,
+          "Republican": 115,
+          "total": 949
+        },
+        "immigra": {
+          "Democratic": 1155,
+          "Republican": 138,
+          "total": 1293
+        },
+        "rights": {
+          "Democratic": 1755,
+          "Republican": 79,
+          "total": 1834
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 239,
+          "Republican": 8,
+          "total": 247
+        },
+        "capitol": {
+          "Democratic": 170,
+          "Republican": 31,
+          "total": 201
+        },
+        "climate": {
+          "Democratic": 926,
+          "Republican": 76,
+          "total": 1002
+        },
+        "covid": {
+          "Democratic": 11297,
+          "Republican": 2045,
+          "total": 13342
+        },
+        "gun": {
+          "Democratic": 834,
+          "Republican": 115,
+          "total": 949
+        },
+        "immigra": {
+          "Democratic": 1155,
+          "Republican": 138,
+          "total": 1293
+        },
+        "rights": {
+          "Democratic": 1755,
+          "Republican": 79,
+          "total": 1834
+        }
+      }
     },
     {
-        "state": "OH",
-        "Democratic": 2314,
-        "Republican": 901,
-        "total": 3215
+      "state": "OH",
+      "Democratic": 2184,
+      "Republican": 868,
+      "total": 3052,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 67,
+          "Republican": 26,
+          "total": 93
+        },
+        "capitol": {
+          "Democratic": 36,
+          "Republican": 11,
+          "total": 47
+        },
+        "climate": {
+          "Democratic": 31,
+          "Republican": 14,
+          "total": 45
+        },
+        "covid": {
+          "Democratic": 1582,
+          "Republican": 666,
+          "total": 2248
+        },
+        "gun": {
+          "Democratic": 227,
+          "Republican": 51,
+          "total": 278
+        },
+        "immigra": {
+          "Democratic": 20,
+          "Republican": 16,
+          "total": 36
+        },
+        "rights": {
+          "Democratic": 221,
+          "Republican": 84,
+          "total": 305
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 67,
+          "Republican": 26,
+          "total": 93
+        },
+        "capitol": {
+          "Democratic": 36,
+          "Republican": 11,
+          "total": 47
+        },
+        "climate": {
+          "Democratic": 31,
+          "Republican": 14,
+          "total": 45
+        },
+        "covid": {
+          "Democratic": 1582,
+          "Republican": 666,
+          "total": 2248
+        },
+        "gun": {
+          "Democratic": 227,
+          "Republican": 51,
+          "total": 278
+        },
+        "immigra": {
+          "Democratic": 20,
+          "Republican": 16,
+          "total": 36
+        },
+        "rights": {
+          "Democratic": 221,
+          "Republican": 84,
+          "total": 305
+        }
+      }
     },
     {
-        "state": "OK",
-        "Democratic": 2460,
-        "Republican": 1156,
-        "total": 3616
+      "state": "OK",
+      "Democratic": 2366,
+      "Republican": 1135,
+      "total": 3501,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 54,
+          "Republican": 33,
+          "total": 87
+        },
+        "capitol": {
+          "Democratic": 93,
+          "Republican": 23,
+          "total": 116
+        },
+        "climate": {
+          "Democratic": 18,
+          "Republican": 6,
+          "total": 24
+        },
+        "covid": {
+          "Democratic": 1894,
+          "Republican": 636,
+          "total": 2530
+        },
+        "gun": {
+          "Democratic": 113,
+          "Republican": 60,
+          "total": 173
+        },
+        "immigra": {
+          "Democratic": 20,
+          "Republican": 16,
+          "total": 36
+        },
+        "rights": {
+          "Democratic": 174,
+          "Republican": 361,
+          "total": 535
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 54,
+          "Republican": 33,
+          "total": 87
+        },
+        "capitol": {
+          "Democratic": 93,
+          "Republican": 23,
+          "total": 116
+        },
+        "climate": {
+          "Democratic": 18,
+          "Republican": 6,
+          "total": 24
+        },
+        "covid": {
+          "Democratic": 1894,
+          "Republican": 636,
+          "total": 2530
+        },
+        "gun": {
+          "Democratic": 113,
+          "Republican": 60,
+          "total": 173
+        },
+        "immigra": {
+          "Democratic": 20,
+          "Republican": 16,
+          "total": 36
+        },
+        "rights": {
+          "Democratic": 174,
+          "Republican": 361,
+          "total": 535
+        }
+      }
     },
     {
-        "state": "OR",
-        "Democratic": 2562,
-        "Republican": 1068,
-        "total": 3630
+      "state": "OR",
+      "Democratic": 2491,
+      "Republican": 1045,
+      "total": 3536,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 31,
+          "Republican": 36,
+          "total": 67
+        },
+        "capitol": {
+          "Democratic": 40,
+          "Republican": 15,
+          "total": 55
+        },
+        "climate": {
+          "Democratic": 212,
+          "Republican": 65,
+          "total": 277
+        },
+        "covid": {
+          "Democratic": 1822,
+          "Republican": 794,
+          "total": 2616
+        },
+        "gun": {
+          "Democratic": 148,
+          "Republican": 81,
+          "total": 229
+        },
+        "immigra": {
+          "Democratic": 40,
+          "Republican": 23,
+          "total": 63
+        },
+        "rights": {
+          "Democratic": 198,
+          "Republican": 31,
+          "total": 229
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 31,
+          "Republican": 36,
+          "total": 67
+        },
+        "capitol": {
+          "Democratic": 40,
+          "Republican": 15,
+          "total": 55
+        },
+        "climate": {
+          "Democratic": 212,
+          "Republican": 65,
+          "total": 277
+        },
+        "covid": {
+          "Democratic": 1822,
+          "Republican": 794,
+          "total": 2616
+        },
+        "gun": {
+          "Democratic": 148,
+          "Republican": 81,
+          "total": 229
+        },
+        "immigra": {
+          "Democratic": 40,
+          "Republican": 23,
+          "total": 63
+        },
+        "rights": {
+          "Democratic": 198,
+          "Republican": 31,
+          "total": 229
+        }
+      }
     },
     {
-        "state": "PA",
-        "Democratic": 12094,
-        "Republican": 4423,
-        "total": 16517
+      "state": "PA",
+      "Democratic": 11749,
+      "Republican": 4386,
+      "total": 16135,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 149,
+          "Republican": 20,
+          "total": 169
+        },
+        "capitol": {
+          "Democratic": 372,
+          "Republican": 31,
+          "total": 403
+        },
+        "climate": {
+          "Democratic": 254,
+          "Republican": 22,
+          "total": 276
+        },
+        "covid": {
+          "Democratic": 9444,
+          "Republican": 3886,
+          "total": 13330
+        },
+        "gun": {
+          "Democratic": 673,
+          "Republican": 119,
+          "total": 792
+        },
+        "immigra": {
+          "Democratic": 129,
+          "Republican": 8,
+          "total": 137
+        },
+        "rights": {
+          "Democratic": 728,
+          "Republican": 300,
+          "total": 1028
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 149,
+          "Republican": 20,
+          "total": 169
+        },
+        "capitol": {
+          "Democratic": 372,
+          "Republican": 31,
+          "total": 403
+        },
+        "climate": {
+          "Democratic": 254,
+          "Republican": 22,
+          "total": 276
+        },
+        "covid": {
+          "Democratic": 9444,
+          "Republican": 3886,
+          "total": 13330
+        },
+        "gun": {
+          "Democratic": 673,
+          "Republican": 119,
+          "total": 792
+        },
+        "immigra": {
+          "Democratic": 129,
+          "Republican": 8,
+          "total": 137
+        },
+        "rights": {
+          "Democratic": 728,
+          "Republican": 300,
+          "total": 1028
+        }
+      }
     },
     {
-        "state": "RI",
-        "Democratic": 3807,
-        "Republican": 1182,
-        "total": 4989
+      "state": "RI",
+      "Democratic": 3568,
+      "Republican": 1152,
+      "total": 4720,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 130,
+          "Republican": 16,
+          "total": 146
+        },
+        "capitol": {
+          "Democratic": 98,
+          "Republican": 35,
+          "total": 133
+        },
+        "climate": {
+          "Democratic": 451,
+          "Republican": 126,
+          "total": 577
+        },
+        "covid": {
+          "Democratic": 1774,
+          "Republican": 649,
+          "total": 2423
+        },
+        "gun": {
+          "Democratic": 828,
+          "Republican": 86,
+          "total": 914
+        },
+        "immigra": {
+          "Democratic": 79,
+          "Republican": 125,
+          "total": 204
+        },
+        "rights": {
+          "Democratic": 208,
+          "Republican": 115,
+          "total": 323
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 130,
+          "Republican": 16,
+          "total": 146
+        },
+        "capitol": {
+          "Democratic": 98,
+          "Republican": 35,
+          "total": 133
+        },
+        "climate": {
+          "Democratic": 451,
+          "Republican": 126,
+          "total": 577
+        },
+        "covid": {
+          "Democratic": 1774,
+          "Republican": 649,
+          "total": 2423
+        },
+        "gun": {
+          "Democratic": 828,
+          "Republican": 86,
+          "total": 914
+        },
+        "immigra": {
+          "Democratic": 79,
+          "Republican": 125,
+          "total": 204
+        },
+        "rights": {
+          "Democratic": 208,
+          "Republican": 115,
+          "total": 323
+        }
+      }
     },
     {
-        "state": "SC",
-        "Democratic": 2600,
-        "Republican": 1619,
-        "total": 4219
+      "state": "SC",
+      "Democratic": 2450,
+      "Republican": 1586,
+      "total": 4036,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 72,
+          "Republican": 31,
+          "total": 103
+        },
+        "capitol": {
+          "Democratic": 114,
+          "Republican": 24,
+          "total": 138
+        },
+        "climate": {
+          "Democratic": 63,
+          "Republican": 32,
+          "total": 95
+        },
+        "covid": {
+          "Democratic": 1822,
+          "Republican": 1347,
+          "total": 3169
+        },
+        "gun": {
+          "Democratic": 128,
+          "Republican": 57,
+          "total": 185
+        },
+        "immigra": {
+          "Democratic": 19,
+          "Republican": 19,
+          "total": 38
+        },
+        "rights": {
+          "Democratic": 232,
+          "Republican": 76,
+          "total": 308
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 72,
+          "Republican": 31,
+          "total": 103
+        },
+        "capitol": {
+          "Democratic": 114,
+          "Republican": 24,
+          "total": 138
+        },
+        "climate": {
+          "Democratic": 63,
+          "Republican": 32,
+          "total": 95
+        },
+        "covid": {
+          "Democratic": 1822,
+          "Republican": 1347,
+          "total": 3169
+        },
+        "gun": {
+          "Democratic": 128,
+          "Republican": 57,
+          "total": 185
+        },
+        "immigra": {
+          "Democratic": 19,
+          "Republican": 19,
+          "total": 38
+        },
+        "rights": {
+          "Democratic": 232,
+          "Republican": 76,
+          "total": 308
+        }
+      }
     },
     {
-        "state": "SD",
-        "Democratic": 362,
-        "Republican": 193,
-        "total": 555
+      "state": "SD",
+      "Democratic": 353,
+      "Republican": 189,
+      "total": 542,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 8,
+          "Republican": 20,
+          "total": 28
+        },
+        "capitol": {
+          "Democratic": 19,
+          "Republican": 0,
+          "total": 19
+        },
+        "climate": {
+          "Democratic": 5,
+          "Republican": 2,
+          "total": 7
+        },
+        "covid": {
+          "Democratic": 263,
+          "Republican": 123,
+          "total": 386
+        },
+        "gun": {
+          "Democratic": 26,
+          "Republican": 13,
+          "total": 39
+        },
+        "immigra": {
+          "Democratic": 9,
+          "Republican": 1,
+          "total": 10
+        },
+        "rights": {
+          "Democratic": 23,
+          "Republican": 30,
+          "total": 53
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 8,
+          "Republican": 20,
+          "total": 28
+        },
+        "capitol": {
+          "Democratic": 19,
+          "Republican": 0,
+          "total": 19
+        },
+        "climate": {
+          "Democratic": 5,
+          "Republican": 2,
+          "total": 7
+        },
+        "covid": {
+          "Democratic": 263,
+          "Republican": 123,
+          "total": 386
+        },
+        "gun": {
+          "Democratic": 26,
+          "Republican": 13,
+          "total": 39
+        },
+        "immigra": {
+          "Democratic": 9,
+          "Republican": 1,
+          "total": 10
+        },
+        "rights": {
+          "Democratic": 23,
+          "Republican": 30,
+          "total": 53
+        }
+      }
     },
     {
-        "state": "TN",
-        "Democratic": 3823,
-        "Republican": 2228,
-        "total": 6051
+      "state": "TN",
+      "Democratic": 3674,
+      "Republican": 2163,
+      "total": 5837,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 102,
+          "Republican": 92,
+          "total": 194
+        },
+        "capitol": {
+          "Democratic": 243,
+          "Republican": 35,
+          "total": 278
+        },
+        "climate": {
+          "Democratic": 51,
+          "Republican": 35,
+          "total": 86
+        },
+        "covid": {
+          "Democratic": 2613,
+          "Republican": 1561,
+          "total": 4174
+        },
+        "gun": {
+          "Democratic": 268,
+          "Republican": 194,
+          "total": 462
+        },
+        "immigra": {
+          "Democratic": 48,
+          "Republican": 32,
+          "total": 80
+        },
+        "rights": {
+          "Democratic": 349,
+          "Republican": 214,
+          "total": 563
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 102,
+          "Republican": 92,
+          "total": 194
+        },
+        "capitol": {
+          "Democratic": 243,
+          "Republican": 35,
+          "total": 278
+        },
+        "climate": {
+          "Democratic": 51,
+          "Republican": 35,
+          "total": 86
+        },
+        "covid": {
+          "Democratic": 2613,
+          "Republican": 1561,
+          "total": 4174
+        },
+        "gun": {
+          "Democratic": 268,
+          "Republican": 194,
+          "total": 462
+        },
+        "immigra": {
+          "Democratic": 48,
+          "Republican": 32,
+          "total": 80
+        },
+        "rights": {
+          "Democratic": 349,
+          "Republican": 214,
+          "total": 563
+        }
+      }
     },
     {
-        "state": "TX",
-        "Democratic": 14614,
-        "Republican": 6607,
-        "total": 21221
+      "state": "TX",
+      "Democratic": 13995,
+      "Republican": 6456,
+      "total": 20451,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 414,
+          "Republican": 274,
+          "total": 688
+        },
+        "capitol": {
+          "Democratic": 152,
+          "Republican": 74,
+          "total": 226
+        },
+        "climate": {
+          "Democratic": 349,
+          "Republican": 52,
+          "total": 401
+        },
+        "covid": {
+          "Democratic": 9717,
+          "Republican": 5131,
+          "total": 14848
+        },
+        "gun": {
+          "Democratic": 700,
+          "Republican": 314,
+          "total": 1014
+        },
+        "immigra": {
+          "Democratic": 502,
+          "Republican": 133,
+          "total": 635
+        },
+        "rights": {
+          "Democratic": 2161,
+          "Republican": 478,
+          "total": 2639
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 414,
+          "Republican": 274,
+          "total": 688
+        },
+        "capitol": {
+          "Democratic": 152,
+          "Republican": 74,
+          "total": 226
+        },
+        "climate": {
+          "Democratic": 349,
+          "Republican": 52,
+          "total": 401
+        },
+        "covid": {
+          "Democratic": 9717,
+          "Republican": 5131,
+          "total": 14848
+        },
+        "gun": {
+          "Democratic": 700,
+          "Republican": 314,
+          "total": 1014
+        },
+        "immigra": {
+          "Democratic": 502,
+          "Republican": 133,
+          "total": 635
+        },
+        "rights": {
+          "Democratic": 2161,
+          "Republican": 478,
+          "total": 2639
+        }
+      }
     },
     {
-        "state": "UT",
-        "Democratic": 2009,
-        "Republican": 850,
-        "total": 2859
+      "state": "UT",
+      "Democratic": 1902,
+      "Republican": 801,
+      "total": 2703,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 67,
+          "Republican": 9,
+          "total": 76
+        },
+        "capitol": {
+          "Democratic": 26,
+          "Republican": 13,
+          "total": 39
+        },
+        "climate": {
+          "Democratic": 79,
+          "Republican": 12,
+          "total": 91
+        },
+        "covid": {
+          "Democratic": 1444,
+          "Republican": 691,
+          "total": 2135
+        },
+        "gun": {
+          "Democratic": 89,
+          "Republican": 22,
+          "total": 111
+        },
+        "immigra": {
+          "Democratic": 59,
+          "Republican": 15,
+          "total": 74
+        },
+        "rights": {
+          "Democratic": 138,
+          "Republican": 39,
+          "total": 177
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 67,
+          "Republican": 9,
+          "total": 76
+        },
+        "capitol": {
+          "Democratic": 26,
+          "Republican": 13,
+          "total": 39
+        },
+        "climate": {
+          "Democratic": 79,
+          "Republican": 12,
+          "total": 91
+        },
+        "covid": {
+          "Democratic": 1444,
+          "Republican": 691,
+          "total": 2135
+        },
+        "gun": {
+          "Democratic": 89,
+          "Republican": 22,
+          "total": 111
+        },
+        "immigra": {
+          "Democratic": 59,
+          "Republican": 15,
+          "total": 74
+        },
+        "rights": {
+          "Democratic": 138,
+          "Republican": 39,
+          "total": 177
+        }
+      }
     },
     {
-        "state": "VA",
-        "Democratic": 8743,
-        "Republican": 700,
-        "total": 9443
+      "state": "VA",
+      "Democratic": 8351,
+      "Republican": 662,
+      "total": 9013,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 181,
+          "Republican": 21,
+          "total": 202
+        },
+        "capitol": {
+          "Democratic": 123,
+          "Republican": 31,
+          "total": 154
+        },
+        "climate": {
+          "Democratic": 361,
+          "Republican": 13,
+          "total": 374
+        },
+        "covid": {
+          "Democratic": 4868,
+          "Republican": 370,
+          "total": 5238
+        },
+        "gun": {
+          "Democratic": 1104,
+          "Republican": 102,
+          "total": 1206
+        },
+        "immigra": {
+          "Democratic": 237,
+          "Republican": 17,
+          "total": 254
+        },
+        "rights": {
+          "Democratic": 1477,
+          "Republican": 108,
+          "total": 1585
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 181,
+          "Republican": 21,
+          "total": 202
+        },
+        "capitol": {
+          "Democratic": 123,
+          "Republican": 31,
+          "total": 154
+        },
+        "climate": {
+          "Democratic": 361,
+          "Republican": 13,
+          "total": 374
+        },
+        "covid": {
+          "Democratic": 4868,
+          "Republican": 370,
+          "total": 5238
+        },
+        "gun": {
+          "Democratic": 1104,
+          "Republican": 102,
+          "total": 1206
+        },
+        "immigra": {
+          "Democratic": 237,
+          "Republican": 17,
+          "total": 254
+        },
+        "rights": {
+          "Democratic": 1477,
+          "Republican": 108,
+          "total": 1585
+        }
+      }
     },
     {
-        "state": "VT",
-        "Democratic": 1679,
-        "Republican": 51,
-        "total": 1730
+      "state": "VT",
+      "Democratic": 1638,
+      "Republican": 51,
+      "total": 1689,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 16,
+          "Republican": 0,
+          "total": 16
+        },
+        "capitol": {
+          "Democratic": 11,
+          "Republican": 0,
+          "total": 11
+        },
+        "climate": {
+          "Democratic": 96,
+          "Republican": 0,
+          "total": 96
+        },
+        "covid": {
+          "Democratic": 1396,
+          "Republican": 48,
+          "total": 1444
+        },
+        "gun": {
+          "Democratic": 39,
+          "Republican": 0,
+          "total": 39
+        },
+        "immigra": {
+          "Democratic": 12,
+          "Republican": 0,
+          "total": 12
+        },
+        "rights": {
+          "Democratic": 68,
+          "Republican": 3,
+          "total": 71
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 16,
+          "Republican": 0,
+          "total": 16
+        },
+        "capitol": {
+          "Democratic": 11,
+          "Republican": 0,
+          "total": 11
+        },
+        "climate": {
+          "Democratic": 96,
+          "Republican": 0,
+          "total": 96
+        },
+        "covid": {
+          "Democratic": 1396,
+          "Republican": 48,
+          "total": 1444
+        },
+        "gun": {
+          "Democratic": 39,
+          "Republican": 0,
+          "total": 39
+        },
+        "immigra": {
+          "Democratic": 12,
+          "Republican": 0,
+          "total": 12
+        },
+        "rights": {
+          "Democratic": 68,
+          "Republican": 3,
+          "total": 71
+        }
+      }
     },
     {
-        "state": "WA",
-        "Democratic": 3136,
-        "Republican": 317,
-        "total": 3453
+      "state": "WA",
+      "Democratic": 3020,
+      "Republican": 308,
+      "total": 3328,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 43,
+          "Republican": 0,
+          "total": 43
+        },
+        "capitol": {
+          "Democratic": 45,
+          "Republican": 17,
+          "total": 62
+        },
+        "climate": {
+          "Democratic": 704,
+          "Republican": 16,
+          "total": 720
+        },
+        "covid": {
+          "Democratic": 1671,
+          "Republican": 219,
+          "total": 1890
+        },
+        "gun": {
+          "Democratic": 225,
+          "Republican": 17,
+          "total": 242
+        },
+        "immigra": {
+          "Democratic": 57,
+          "Republican": 9,
+          "total": 66
+        },
+        "rights": {
+          "Democratic": 275,
+          "Republican": 30,
+          "total": 305
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 43,
+          "Republican": 0,
+          "total": 43
+        },
+        "capitol": {
+          "Democratic": 45,
+          "Republican": 17,
+          "total": 62
+        },
+        "climate": {
+          "Democratic": 704,
+          "Republican": 16,
+          "total": 720
+        },
+        "covid": {
+          "Democratic": 1671,
+          "Republican": 219,
+          "total": 1890
+        },
+        "gun": {
+          "Democratic": 225,
+          "Republican": 17,
+          "total": 242
+        },
+        "immigra": {
+          "Democratic": 57,
+          "Republican": 9,
+          "total": 66
+        },
+        "rights": {
+          "Democratic": 275,
+          "Republican": 30,
+          "total": 305
+        }
+      }
     },
     {
-        "state": "WI",
-        "Democratic": 2936,
-        "Republican": 1024,
-        "total": 3960
+      "state": "WI",
+      "Democratic": 2779,
+      "Republican": 1009,
+      "total": 3788,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 51,
+          "Republican": 19,
+          "total": 70
+        },
+        "capitol": {
+          "Democratic": 62,
+          "Republican": 34,
+          "total": 96
+        },
+        "climate": {
+          "Democratic": 132,
+          "Republican": 13,
+          "total": 145
+        },
+        "covid": {
+          "Democratic": 2139,
+          "Republican": 805,
+          "total": 2944
+        },
+        "gun": {
+          "Democratic": 120,
+          "Republican": 38,
+          "total": 158
+        },
+        "immigra": {
+          "Democratic": 40,
+          "Republican": 25,
+          "total": 65
+        },
+        "rights": {
+          "Democratic": 235,
+          "Republican": 75,
+          "total": 310
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 51,
+          "Republican": 19,
+          "total": 70
+        },
+        "capitol": {
+          "Democratic": 62,
+          "Republican": 34,
+          "total": 96
+        },
+        "climate": {
+          "Democratic": 132,
+          "Republican": 13,
+          "total": 145
+        },
+        "covid": {
+          "Democratic": 2139,
+          "Republican": 805,
+          "total": 2944
+        },
+        "gun": {
+          "Democratic": 120,
+          "Republican": 38,
+          "total": 158
+        },
+        "immigra": {
+          "Democratic": 40,
+          "Republican": 25,
+          "total": 65
+        },
+        "rights": {
+          "Democratic": 235,
+          "Republican": 75,
+          "total": 310
+        }
+      }
     },
     {
-        "state": "WV",
-        "Democratic": 531,
-        "Republican": 858,
-        "total": 1389
+      "state": "WV",
+      "Democratic": 504,
+      "Republican": 824,
+      "total": 1328,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 8,
+          "Republican": 15,
+          "total": 23
+        },
+        "capitol": {
+          "Democratic": 43,
+          "Republican": 17,
+          "total": 60
+        },
+        "climate": {
+          "Democratic": 11,
+          "Republican": 15,
+          "total": 26
+        },
+        "covid": {
+          "Democratic": 394,
+          "Republican": 588,
+          "total": 982
+        },
+        "gun": {
+          "Democratic": 13,
+          "Republican": 58,
+          "total": 71
+        },
+        "immigra": {
+          "Democratic": 2,
+          "Republican": 12,
+          "total": 14
+        },
+        "rights": {
+          "Democratic": 33,
+          "Republican": 119,
+          "total": 152
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 8,
+          "Republican": 15,
+          "total": 23
+        },
+        "capitol": {
+          "Democratic": 43,
+          "Republican": 17,
+          "total": 60
+        },
+        "climate": {
+          "Democratic": 11,
+          "Republican": 15,
+          "total": 26
+        },
+        "covid": {
+          "Democratic": 394,
+          "Republican": 588,
+          "total": 982
+        },
+        "gun": {
+          "Democratic": 13,
+          "Republican": 58,
+          "total": 71
+        },
+        "immigra": {
+          "Democratic": 2,
+          "Republican": 12,
+          "total": 14
+        },
+        "rights": {
+          "Democratic": 33,
+          "Republican": 119,
+          "total": 152
+        }
+      }
     },
     {
-        "state": "WY",
-        "Democratic": 80,
-        "Republican": 225,
-        "total": 305
+      "state": "WY",
+      "Democratic": 75,
+      "Republican": 223,
+      "total": 298,
+      "topic_breakdown": {
+        "abortion": {
+          "Democratic": 3,
+          "Republican": 13,
+          "total": 16
+        },
+        "capitol": {
+          "Democratic": 1,
+          "Republican": 6,
+          "total": 7
+        },
+        "climate": {
+          "Democratic": 8,
+          "Republican": 4,
+          "total": 12
+        },
+        "covid": {
+          "Democratic": 55,
+          "Republican": 122,
+          "total": 177
+        },
+        "gun": {
+          "Democratic": 5,
+          "Republican": 38,
+          "total": 43
+        },
+        "immigra": {
+          "Democratic": 1,
+          "Republican": 4,
+          "total": 5
+        },
+        "rights": {
+          "Democratic": 2,
+          "Republican": 36,
+          "total": 38
+        }
+      },
+      "legislator_breakdown": {
+        "abortion": {
+          "Democratic": 3,
+          "Republican": 13,
+          "total": 16
+        },
+        "capitol": {
+          "Democratic": 1,
+          "Republican": 6,
+          "total": 7
+        },
+        "climate": {
+          "Democratic": 8,
+          "Republican": 4,
+          "total": 12
+        },
+        "covid": {
+          "Democratic": 55,
+          "Republican": 122,
+          "total": 177
+        },
+        "gun": {
+          "Democratic": 5,
+          "Republican": 38,
+          "total": 43
+        },
+        "immigra": {
+          "Democratic": 1,
+          "Republican": 4,
+          "total": 5
+        },
+        "rights": {
+          "Democratic": 2,
+          "Republican": 36,
+          "total": 38
+        }
+      }
     }
-]
+  ]

--- a/frontend/src/components/Base/TabbedCharts.jsx
+++ b/frontend/src/components/Base/TabbedCharts.jsx
@@ -226,6 +226,7 @@ useEffect(() => {
               selectedTopics: memoTopics,
               selectedMetric,
               legislator,
+              keyword,
             }}
           />
         );

--- a/frontend/src/components/Geography/ChoroplethMap.jsx
+++ b/frontend/src/components/Geography/ChoroplethMap.jsx
@@ -1,13 +1,15 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
 import PropTypes from 'prop-types';
+import tippy from 'tippy.js';
+import 'tippy.js/dist/tippy.css';
 
-function ChoroplethMap({ 
-  geojson, 
-  geoData, 
-  selectedMetric, 
-  startDate, 
-  endDate, 
+function ChoroplethMap({
+  geojson,
+  geoData,
+  selectedMetric,
+  startDate,
+  endDate,
   selectedTopics,
   onStateSelected,
   showLegend = false,
@@ -17,6 +19,13 @@ function ChoroplethMap({
 }) {
   const svgRef = useRef();
 
+  // Helper to format large numbers
+  const formatNumber = (num) => {
+    if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
+    if (num >= 1000) return `${(num / 1000).toFixed(1)}K`;
+    return num;
+  };
+
   useEffect(() => {
     if (!geojson || geoData.length === 0) return;
 
@@ -24,27 +33,20 @@ function ChoroplethMap({
       .attr('viewBox', '0 0 960 600')
       .attr('preserveAspectRatio', 'xMidYMid meet');
 
+    // Clear previous contents
     svg.selectAll('*').remove();
 
-    const tooltip = d3.select('body').append('div')
-      .attr('class', 'tooltip')
-      .style('position', 'absolute')
-      .style('pointer-events', 'none')
-      .style('background', 'var(--b2, #e0f7fa)')
-      .style('color', 'var(--bc, #333)')
-      .style('border', '1px solid var(--b3, #ccc)')
-      .style('padding', '10px')
-      .style('font-size', '14px')
-      .style('border-radius', '6px')
-      .style('box-shadow', '0 2px 6px rgba(0,0,0,0.15)')
-      .style('opacity', 0)
-      .style('z-index', 9999);
+    // 1) Create a geoPath generator
+    const path = d3.geoPath(
+      d3.geoAlbersUsa()
+        .scale(1300)
+        .translate([487.5, 305])
+    );
 
-    const path = d3.geoPath(d3.geoAlbersUsa().scale(1300).translate([487.5, 305]));
-
+    // 2) Build a lookup map: stateName → stateData
     const stateGeoMap = new Map(geoData.map(d => [d.state, d]));
 
-    // Normalization logic
+    // 3) Compute normalization stats once
     const demValues = geoData.map(d => d.democratTotal);
     const repValues = geoData.map(d => d.republicanTotal);
     const demMean = d3.mean(demValues);
@@ -52,97 +54,108 @@ function ChoroplethMap({
     const demStdDev = d3.deviation(demValues) || 1;
     const repStdDev = d3.deviation(repValues) || 1;
 
-    // Color calculation for raw and normalized data
-    const getColor = (stateName) => {
-      const stateData = stateGeoMap.get(stateName);
-      if (!stateData) return '#eee';
-
-      const { democratTotal, republicanTotal } = stateData;
-
-      // Normalize data based on toggle
-      if (isNormalized) {
-        const demZ = (democratTotal - demMean) / demStdDev;
-        const repZ = (republicanTotal - repMean) / repStdDev;
-
-        if (isNaN(demZ) || isNaN(repZ)) return '#eee';
-        console.log(`Normalized Z-Scores -> Democrat: ${demZ}, Republican: ${repZ}`); // Debugging output
-        return demZ > repZ ? blueScale(democratTotal) : redScale(republicanTotal);
-      } else {
-        console.log(`Raw data -> Democrat: ${democratTotal}, Republican: ${republicanTotal}`); // Debugging output
-        // Use raw data when normalized is false
-        return democratTotal > republicanTotal ? blueScale(democratTotal) : redScale(republicanTotal);
-      }
-    };
-
-    const metricLabel = selectedMetric === 'posts' ? 'Total Posts' : 
-                        selectedMetric === 'legislators' ? 'Total Legislators' : 
-                        'Total Engagement';
-
+    // 4) Draw each state path, and update its data-tippy-content:
     svg.append('g')
       .selectAll('path')
       .data(geojson.features)
       .join('path')
+      .attr('class', 'state-shape')
       .attr('d', path)
-      .attr('fill', d => getColor(d.properties.name))
+      .attr('fill', d => {
+        const s = stateGeoMap.get(d.properties.name);
+        if (!s) return '#eee';
+        if (isNormalized) {
+          const demZ = (s.democratTotal - demMean) / demStdDev;
+          const repZ = (s.republicanTotal - repMean) / repStdDev;
+          if (isNaN(demZ) || isNaN(repZ)) return '#eee';
+          return demZ > repZ
+            ? blueScale(s.democratTotal)
+            : redScale(s.republicanTotal);
+        }
+        return s.democratTotal > s.republicanTotal
+          ? blueScale(s.democratTotal)
+          : redScale(s.republicanTotal);
+      })
       .attr('stroke', '#fff')
       .attr('stroke-width', 0.5)
-      .on('mousemove', function (event, d) {
-        const stateName = d.properties.name;
-        const stateData = stateGeoMap.get(stateName);
-        if (!stateData) return;
-
-        const tooltipHtml = `
-        <strong>${stateName}</strong><br/>
-        <strong>${metricLabel}:</strong> ${formatNumber(stateData.total_engagement)}<br/>
-        <strong>From:</strong> ${startDate.format('YYYY-MM-DD')} to ${endDate.format('YYYY-MM-DD')}<br/>
-        <strong>Topics:</strong> ${selectedTopics.join(', ') || 'All topics'}<br/>
-        <strong>Democrats:</strong> ${isNormalized ? formatNumber((stateData.democratTotal - demMean) / demStdDev) : formatNumber(stateData.democratTotal)}<br/>
-        <strong>Republicans:</strong> ${isNormalized ? formatNumber((stateData.republicanTotal - repMean) / repStdDev) : formatNumber(stateData.republicanTotal)}<br/>
-        <strong>${isNormalized ? 'Normalized' : 'Raw'} Data</strong><br/>
-      `;
-
-        tooltip
-          .html(tooltipHtml)
-          .style("left", `${event.pageX + 10}px`)
-          .style("top", `${event.pageY + 10}px`)
-          .transition().duration(100)
-          .style("opacity", 0.95);
-      })
-      .on('mouseout', () => {
-        tooltip.transition().duration(300).style('opacity', 0);
-      })
       .on('click', (event, d) => {
         const stateName = d.properties.name;
-        const stateData = stateGeoMap.get(stateName);
-        if (stateData) {
+        const s = stateGeoMap.get(stateName);
+        if (s) {
           onStateSelected({
             name: stateName,
-            topicBreakdown: stateData.topic_breakdown,
+            topicBreakdown: s.topic_breakdown,
           });
         }
+      })
+      .attr('data-tippy-content', d => {
+        const stateName = d.properties.name;
+        const s = stateGeoMap.get(stateName);
+        if (!s) return '';
+        const metricLabel = selectedMetric === 'posts'
+          ? 'Total Posts'
+          : selectedMetric === 'legislators'
+          ? 'Total Legislators'
+          : 'Total Engagement';
+
+        const demDisplay = isNormalized
+          ? formatNumber((s.democratTotal - demMean) / demStdDev)
+          : formatNumber(s.democratTotal);
+
+        const repDisplay = isNormalized
+          ? formatNumber((s.republicanTotal - repMean) / repStdDev)
+          : formatNumber(s.republicanTotal);
+
+        const totalDisplay = formatNumber(s.total_engagement);
+        const topicsDisplay = selectedTopics.length
+          ? selectedTopics.join(', ')
+          : 'All topics';
+
+        return [
+          `<strong>${stateName}</strong>`,
+          `<strong>${metricLabel}:</strong> ${totalDisplay}`,
+          `<strong>From:</strong> ${startDate.format('YYYY-MM-DD')} to ${endDate.format('YYYY-MM-DD')}`,
+          `<strong>Topics:</strong> ${topicsDisplay}`,
+          `<strong>Democrats:</strong> ${demDisplay}`,
+          `<strong>Republicans:</strong> ${repDisplay}`,
+          `<strong>${isNormalized ? 'Normalized' : 'Raw'} Data</strong>`
+        ].join('<br/>');
       });
 
-    return () => tooltip.remove();
-  }, [geojson, geoData, selectedMetric, startDate, endDate, selectedTopics, onStateSelected, blueScale, redScale, isNormalized]);
-
-  const formatNumber = (num) => {
-    if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
-    if (num >= 1000) return `${(num / 1000).toFixed(1)}K`;
-    return num;
-  };
+    // 5) Initialize Tippy on every element with class "state-shape"
+    tippy('.state-shape', {
+      allowHTML: true,
+      placement: 'right',
+      animation: 'fade',
+      delay: [0, 50],
+      duration: [0, 0]
+      // No need for a `content` callback because Tippy reads data-tippy-content directly
+    });
+  }, [
+    geojson,
+    geoData,
+    selectedMetric,
+    startDate,
+    endDate,
+    selectedTopics,
+    onStateSelected,
+    blueScale,
+    redScale,
+    isNormalized
+  ]);
 
   return (
     <>
       <svg ref={svgRef} style={{ width: '100%' }} />
-      
+
       {showLegend && (
         <div style={{ display: 'flex', gap: '20px', marginTop: '10px', justifyContent: 'center' }}>
           <div style={{ display: 'flex', alignItems: 'center' }}>
-            <div style={{ width: '20px', height: '20px', backgroundColor: '#1e3a8a', marginRight: '6px' }}></div>
+            <div style={{ width: '20px', height: '20px', backgroundColor: '#1e3a8a', marginRight: '6px' }} />
             <span className="text-base-content">Democrat</span>
           </div>
           <div style={{ display: 'flex', alignItems: 'center' }}>
-            <div style={{ width: '20px', height: '20px', backgroundColor: '#cc0000', marginRight: '6px' }}></div>
+            <div style={{ width: '20px', height: '20px', backgroundColor: '#cc0000', marginRight: '6px' }} />
             <span className="text-base-content">Republican</span>
           </div>
         </div>
@@ -161,8 +174,8 @@ ChoroplethMap.propTypes = {
   onStateSelected: PropTypes.func,
   showLegend: PropTypes.bool,
   blueScale: PropTypes.func,
-  redScale: PropTypes.func
+  redScale: PropTypes.func,
+  isNormalized: PropTypes.bool
 };
 
 export default ChoroplethMap;
-


### PR DESCRIPTION
- Prefetch static JSON for choropleth for default dates
- Switched to Tippy tooltips (minor lag, investigating)